### PR TITLE
Adding option to select GPU device for offscreen renderer

### DIFF
--- a/robosuite/environments/base.py
+++ b/robosuite/environments/base.py
@@ -80,6 +80,8 @@ class MujocoEnv(metaclass=EnvMeta):
         render_visual_mesh (bool): True if rendering visual meshes
             in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive
             in every simulated second. This sets the amount of simulation time
             that passes between every action input.
@@ -104,6 +106,7 @@ class MujocoEnv(metaclass=EnvMeta):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -119,6 +122,7 @@ class MujocoEnv(metaclass=EnvMeta):
         self.render_camera = render_camera
         self.render_collision_mesh = render_collision_mesh
         self.render_visual_mesh = render_visual_mesh
+        self.render_gpu_device_id = render_gpu_device_id
         self.viewer = None
 
         # whether to use indicator object or not
@@ -246,7 +250,7 @@ class MujocoEnv(metaclass=EnvMeta):
 
         elif self.has_offscreen_renderer:
             if self.sim._render_context_offscreen is None:
-                render_context = MjRenderContextOffscreen(self.sim)
+                render_context = MjRenderContextOffscreen(self.sim, device_id=self.render_gpu_device_id)
                 self.sim.add_render_context(render_context)
             self.sim._render_context_offscreen.vopt.geomgroup[0] = (1 if self.render_collision_mesh else 0)
             self.sim._render_context_offscreen.vopt.geomgroup[1] = (1 if self.render_visual_mesh else 0)

--- a/robosuite/environments/base.py
+++ b/robosuite/environments/base.py
@@ -81,6 +81,8 @@ class MujocoEnv(metaclass=EnvMeta):
             in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive
             in every simulated second. This sets the amount of simulation time

--- a/robosuite/environments/manipulation/door.py
+++ b/robosuite/environments/manipulation/door.py
@@ -91,6 +91,8 @@ class Door(SingleArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -148,6 +150,7 @@ class Door(SingleArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -189,6 +192,7 @@ class Door(SingleArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/door.py
+++ b/robosuite/environments/manipulation/door.py
@@ -92,6 +92,8 @@ class Door(SingleArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/lift.py
+++ b/robosuite/environments/manipulation/lift.py
@@ -97,6 +97,8 @@ class Lift(SingleArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/lift.py
+++ b/robosuite/environments/manipulation/lift.py
@@ -96,6 +96,8 @@ class Lift(SingleArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -154,6 +156,7 @@ class Lift(SingleArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -195,6 +198,7 @@ class Lift(SingleArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/manipulation_env.py
+++ b/robosuite/environments/manipulation/manipulation_env.py
@@ -78,6 +78,8 @@ class ManipulationEnv(RobotEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -132,6 +134,7 @@ class ManipulationEnv(RobotEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -174,6 +177,7 @@ class ManipulationEnv(RobotEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/manipulation_env.py
+++ b/robosuite/environments/manipulation/manipulation_env.py
@@ -79,6 +79,8 @@ class ManipulationEnv(RobotEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/nut_assembly.py
+++ b/robosuite/environments/manipulation/nut_assembly.py
@@ -111,6 +111,8 @@ class NutAssembly(SingleArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -172,6 +174,7 @@ class NutAssembly(SingleArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -225,6 +228,7 @@ class NutAssembly(SingleArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/nut_assembly.py
+++ b/robosuite/environments/manipulation/nut_assembly.py
@@ -112,6 +112,8 @@ class NutAssembly(SingleArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/pick_place.py
+++ b/robosuite/environments/manipulation/pick_place.py
@@ -122,6 +122,8 @@ class PickPlace(SingleArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -184,6 +186,7 @@ class PickPlace(SingleArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -240,6 +243,7 @@ class PickPlace(SingleArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/pick_place.py
+++ b/robosuite/environments/manipulation/pick_place.py
@@ -123,6 +123,8 @@ class PickPlace(SingleArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/stack.py
+++ b/robosuite/environments/manipulation/stack.py
@@ -96,6 +96,8 @@ class Stack(SingleArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -154,6 +156,7 @@ class Stack(SingleArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -195,6 +198,7 @@ class Stack(SingleArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/stack.py
+++ b/robosuite/environments/manipulation/stack.py
@@ -97,6 +97,8 @@ class Stack(SingleArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/two_arm_handover.py
+++ b/robosuite/environments/manipulation/two_arm_handover.py
@@ -107,6 +107,8 @@ class TwoArmHandover(TwoArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/two_arm_handover.py
+++ b/robosuite/environments/manipulation/two_arm_handover.py
@@ -106,6 +106,8 @@ class TwoArmHandover(TwoArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -167,6 +169,7 @@ class TwoArmHandover(TwoArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -214,6 +217,7 @@ class TwoArmHandover(TwoArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/two_arm_lift.py
+++ b/robosuite/environments/manipulation/two_arm_lift.py
@@ -105,6 +105,8 @@ class TwoArmLift(TwoArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/two_arm_lift.py
+++ b/robosuite/environments/manipulation/two_arm_lift.py
@@ -104,6 +104,8 @@ class TwoArmLift(TwoArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -164,6 +166,7 @@ class TwoArmLift(TwoArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -205,6 +208,7 @@ class TwoArmLift(TwoArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/two_arm_peg_in_hole.py
+++ b/robosuite/environments/manipulation/two_arm_peg_in_hole.py
@@ -99,6 +99,8 @@ class TwoArmPegInHole(TwoArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/manipulation/two_arm_peg_in_hole.py
+++ b/robosuite/environments/manipulation/two_arm_peg_in_hole.py
@@ -98,6 +98,8 @@ class TwoArmPegInHole(TwoArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -158,6 +160,7 @@ class TwoArmPegInHole(TwoArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -198,6 +201,7 @@ class TwoArmPegInHole(TwoArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/wipe.py
+++ b/robosuite/environments/manipulation/wipe.py
@@ -118,6 +118,8 @@ class Wipe(SingleArmEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -179,6 +181,7 @@ class Wipe(SingleArmEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -277,6 +280,7 @@ class Wipe(SingleArmEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,

--- a/robosuite/environments/manipulation/wipe.py
+++ b/robosuite/environments/manipulation/wipe.py
@@ -119,6 +119,8 @@ class Wipe(SingleArmEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/robot_env.py
+++ b/robosuite/environments/robot_env.py
@@ -70,6 +70,8 @@ class RobotEnv(MujocoEnv):
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
         render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+            Defaults to -1, in which case the device will be inferred from environment variables
+            (GPUS or CUDA_VISIBLE_DEVICES).
 
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.

--- a/robosuite/environments/robot_env.py
+++ b/robosuite/environments/robot_env.py
@@ -69,6 +69,8 @@ class RobotEnv(MujocoEnv):
 
         render_visual_mesh (bool): True if rendering visual meshes in camera. False otherwise.
 
+        render_gpu_device_id (int): corresponds to the GPU device id to use for offscreen rendering.
+
         control_freq (float): how many control signals to receive in every second. This sets the amount of
             simulation time that passes between every action input.
 
@@ -123,6 +125,7 @@ class RobotEnv(MujocoEnv):
         render_camera="frontview",
         render_collision_mesh=False,
         render_visual_mesh=True,
+        render_gpu_device_id=-1,
         control_freq=10,
         horizon=1000,
         ignore_done=False,
@@ -201,6 +204,7 @@ class RobotEnv(MujocoEnv):
             render_camera=render_camera,
             render_collision_mesh=render_collision_mesh,
             render_visual_mesh=render_visual_mesh,
+            render_gpu_device_id=render_gpu_device_id,
             control_freq=control_freq,
             horizon=horizon,
             ignore_done=ignore_done,


### PR DESCRIPTION
- All environments now have an argument called `render_gpu_device_id` allowing for selection of GPU device to use for offscreen rendering. This is important for multi-GPU machines.