### PR TITLE
Fix tune camera

### DIFF
--- a/robosuite/scripts/tune_camera.py
+++ b/robosuite/scripts/tune_camera.py
@@ -13,6 +13,7 @@ import numpy as np
 
 import robosuite
 import robosuite.utils.transform_utils as T
+from robosuite.utils.mjcf_utils import find_elements, find_parent
 
 # some settings
 DELTA_POS_KEY_PRESS = 0.05      # delta camera position per key press
@@ -23,12 +24,12 @@ def modify_xml_for_camera_movement(xml, camera_name):
     """
     Cameras in mujoco are 'fixed', so they can't be moved by default.
     Although it's possible to hack position movement, rotation movement
-    does not work. An alternative is to attach a camera to a mocap body,
-    and move the mocap body.
+    does not work. An alternative is to attach a camera to a body element,
+    and move the body.
 
     This function modifies the camera with name @camera_name in the xml
-    by attaching it to a mocap body that can move around freely. In this
-    way, we can move the camera by moving the mocap body.
+    by attaching it to a body element that we can then manipulate. In this
+    way, we can move the camera by moving the body.
 
     See http://www.mujoco.org/forum/index.php?threads/move-camera.2201/ for
     further details.
@@ -37,66 +38,75 @@ def modify_xml_for_camera_movement(xml, camera_name):
     camera_name (str): Name of camera to tune
     """
     tree = ET.fromstring(xml)
-    wb = tree.find("worldbody")
 
     # find the correct camera
     camera_elem = None
-    cameras = wb.findall("camera")
+    cameras = find_elements(root=tree, tags="camera", return_first=False)
     for camera in cameras:
         if camera.get("name") == camera_name:
             camera_elem = camera
             break
-    assert(camera_elem is not None)
+    assert camera_elem is not None, "No valid camera name found, options are: {}"\
+        .format([camera.get("name") for camera in cameras])
 
-    # add mocap body
-    mocap = ET.SubElement(wb, "body")
-    mocap.set("name", "cameramover")
-    mocap.set("mocap", "true")
-    mocap.set("pos", camera.get("pos"))
-    mocap.set("quat", camera.get("quat"))
-    new_camera = ET.SubElement(mocap, "camera")
+    # Find parent element of the camera element
+    parent = find_parent(root=tree, child=camera_elem)
+    assert parent is not None
+
+    # add camera body
+    cam_body = ET.SubElement(parent, "body")
+    cam_body.set("name", "cameramover")
+    cam_body.set("pos", camera_elem.get("pos"))
+    cam_body.set("quat", camera_elem.get("quat"))
+    new_camera = ET.SubElement(cam_body, "camera")
     new_camera.set("mode", "fixed")
-    new_camera.set("name", camera.get("name"))
+    new_camera.set("name", camera_elem.get("name"))
     new_camera.set("pos", "0 0 0")
+    # Also need to define inertia
+    inertial = ET.SubElement(cam_body, "inertial")
+    inertial.set("diaginertia", "1e-08 1e-08 1e-08")
+    inertial.set("mass", "1e-08")
+    inertial.set("pos", "0 0 0")
 
     # remove old camera element
-    wb.remove(camera_elem)
+    parent.remove(camera_elem)
 
     return ET.tostring(tree, encoding="utf8").decode("utf8")
 
 
-def move_camera(env, direction, scale, camera_id):
+def move_camera(env, direction, scale, cam_body_id):
     """
     Move the camera view along a direction (in the camera frame).
 
     Args:
         direction (np.arry): 3-array for where to move camera in camera frame
         scale (float): how much to move along that direction
-        camera_id (int): which camera to modify
+        cam_body_id (int): id corresponding to parent body of camera element
     """
 
     # current camera pose
-    camera_pos = np.array(env.sim.data.get_mocap_pos("cameramover"))
-    camera_rot = T.quat2mat(T.convert_quat(env.sim.data.get_mocap_quat("cameramover"), to='xyzw'))
+    camera_pos = np.array(env.sim.model.body_pos[cam_body_id])
+    camera_rot = T.quat2mat(T.convert_quat(env.sim.model.body_quat[cam_body_id], to='xyzw'))
 
     # move along camera frame axis and set new position
-    camera_pos += scale * camera_rot.dot(direction) 
-    env.sim.data.set_mocap_pos("cameramover", camera_pos)
+    camera_pos += scale * camera_rot.dot(direction)
+    env.sim.model.body_pos[cam_body_id] = camera_pos
     env.sim.forward()
 
 
-def rotate_camera(env, direction, angle, camera_id):
+def rotate_camera(env, direction, angle, cam_body_id):
     """
     Rotate the camera view about a direction (in the camera frame).
 
     Args:
         direction (np.array): 3-array for where to move camera in camera frame
         angle (float): how much to rotate about that direction
-        camera_id (int): which camera to modify
+        cam_body_id (int): id corresponding to parent body of camera element
     """
 
     # current camera rotation
-    camera_rot = T.quat2mat(T.convert_quat(env.sim.data.get_mocap_quat("cameramover"), to='xyzw'))
+    camera_pos = np.array(env.sim.model.body_pos[cam_body_id])
+    camera_rot = T.quat2mat(T.convert_quat(env.sim.model.body_quat[cam_body_id], to='xyzw'))
 
     # rotate by angle and direction to get new camera rotation
     rad = np.pi * angle / 180.0
@@ -104,21 +114,21 @@ def rotate_camera(env, direction, angle, camera_id):
     camera_rot = camera_rot.dot(R[:3, :3])
 
     # set new rotation
-    env.sim.data.set_mocap_quat("cameramover", T.convert_quat(T.mat2quat(camera_rot), to='wxyz'))
+    env.sim.model.body_quat[cam_body_id] = T.convert_quat(T.mat2quat(camera_rot), to='wxyz')
     env.sim.forward()
 
 
 class KeyboardHandler:
-    def __init__(self, env, camera_id):
+    def __init__(self, env, cam_body_id):
         """
         Store internal state here.
 
         Args:
             env (MujocoEnv): Environment to use
-            camera_id (int): which camera to modify
+        cam_body_id (int): id corresponding to parent body of camera element
         """
         self.env = env
-        self.camera_id = camera_id
+        self.cam_body_id = cam_body_id
 
     def on_press(self, window, key, scancode, action, mods):
         """
@@ -134,42 +144,42 @@ class KeyboardHandler:
         # controls for moving position
         if key == glfw.KEY_W:
             # move forward
-            move_camera(env=self.env, direction=[0., 0., -1.], scale=DELTA_POS_KEY_PRESS, camera_id=self.camera_id)
+            move_camera(env=self.env, direction=[0., 0., -1.], scale=DELTA_POS_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_S:
             # move backward
-            move_camera(env=self.env, direction=[0., 0., 1.], scale=DELTA_POS_KEY_PRESS, camera_id=self.camera_id)
+            move_camera(env=self.env, direction=[0., 0., 1.], scale=DELTA_POS_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_A:
             # move left
-            move_camera(env=self.env, direction=[-1., 0., 0.], scale=DELTA_POS_KEY_PRESS, camera_id=self.camera_id)
+            move_camera(env=self.env, direction=[-1., 0., 0.], scale=DELTA_POS_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_D:
             # move right
-            move_camera(env=self.env, direction=[1., 0., 0.], scale=DELTA_POS_KEY_PRESS, camera_id=self.camera_id)
+            move_camera(env=self.env, direction=[1., 0., 0.], scale=DELTA_POS_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_R:
             # move up
-            move_camera(env=self.env, direction=[0., 1., 0.], scale=DELTA_POS_KEY_PRESS, camera_id=self.camera_id)
+            move_camera(env=self.env, direction=[0., 1., 0.], scale=DELTA_POS_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_F:
             # move down
-            move_camera(env=self.env, direction=[0., -1., 0.], scale=DELTA_POS_KEY_PRESS, camera_id=self.camera_id)
+            move_camera(env=self.env, direction=[0., -1., 0.], scale=DELTA_POS_KEY_PRESS, cam_body_id=self.cam_body_id)
 
         # controls for moving rotation
         elif key == glfw.KEY_UP:
             # rotate up
-            rotate_camera(env=self.env, direction=[1., 0., 0.], angle=DELTA_ROT_KEY_PRESS, camera_id=self.camera_id)
+            rotate_camera(env=self.env, direction=[1., 0., 0.], angle=DELTA_ROT_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_DOWN:
             # rotate down
-            rotate_camera(env=self.env, direction=[-1., 0., 0.], angle=DELTA_ROT_KEY_PRESS, camera_id=self.camera_id)
+            rotate_camera(env=self.env, direction=[-1., 0., 0.], angle=DELTA_ROT_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_LEFT:
             # rotate left
-            rotate_camera(env=self.env, direction=[0., 1., 0.], angle=DELTA_ROT_KEY_PRESS, camera_id=self.camera_id)
+            rotate_camera(env=self.env, direction=[0., 1., 0.], angle=DELTA_ROT_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_RIGHT:
             # rotate right
-            rotate_camera(env=self.env, direction=[0., -1., 0.], angle=DELTA_ROT_KEY_PRESS, camera_id=self.camera_id)
+            rotate_camera(env=self.env, direction=[0., -1., 0.], angle=DELTA_ROT_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_PERIOD:
             # rotate counterclockwise
-            rotate_camera(env=self.env, direction=[0., 0., 1.], angle=DELTA_ROT_KEY_PRESS, camera_id=self.camera_id)
+            rotate_camera(env=self.env, direction=[0., 0., 1.], angle=DELTA_ROT_KEY_PRESS, cam_body_id=self.cam_body_id)
         elif key == glfw.KEY_SLASH:
             # rotate clockwise
-            rotate_camera(env=self.env, direction=[0., 0., -1.], angle=DELTA_ROT_KEY_PRESS, camera_id=self.camera_id)
+            rotate_camera(env=self.env, direction=[0., 0., -1.], angle=DELTA_ROT_KEY_PRESS, cam_body_id=self.cam_body_id)
 
     def on_release(self, window, key, scancode, action, mods):
         """
@@ -216,7 +226,9 @@ if __name__ == "__main__":
     print("")
 
     # read camera XML tag from user input
-    inp = input("\nPlease paste a camera xml tag below (e.g. <camera ... />) \nOR leave blank for an example:\n")
+    inp = input("\nPlease paste a camera name below \n"
+                "OR xml tag below (e.g. <camera ... />) \n"
+                "OR leave blank for an example:\n")
 
     if len(inp) == 0:
         if args.env != "Lift":
@@ -224,16 +236,17 @@ if __name__ == "__main__":
         print("\nUsing an example tag corresponding to the frontview camera.")
         print("This xml tag was copied from robosuite/models/assets/arenas/table_arena.xml")
         inp = '<camera mode="fixed" name="frontview" pos="1.6 0 1.45" quat="0.56 0.43 0.43 0.56"/>'
-    
-    print("NOTE: using the following xml tag:\n")
-    print("{}\n".format(inp))
 
     # remember the tag and infer some properties
-    cam_tree = ET.fromstring(inp)
+    from_tag = "<" in inp
+    notify_str = "NOTE: using the following xml tag:\n" if from_tag else \
+        "NOTE: using the following camera (initialized at default sim location)\n"
+
+    print(notify_str)
+    print("{}\n".format(inp))
+
+    cam_tree = ET.fromstring(inp) if from_tag else ET.Element("camera", attrib={"name": inp})
     CAMERA_NAME = cam_tree.get("name")
-    initial_file_camera_pos = np.array(cam_tree.get("pos").split(" ")).astype(float)
-    initial_file_camera_quat = T.convert_quat(np.array(cam_tree.get("quat").split(" ")).astype(float), to='xyzw')
-    initial_file_camera_pose = T.make_pose(initial_file_camera_pos, T.quat2mat(initial_file_camera_quat))
 
     # make the environment
     env = robosuite.make(
@@ -249,7 +262,7 @@ if __name__ == "__main__":
     initial_mjstate = env.sim.get_state().flatten()
     xml = env.sim.model.get_xml()
 
-    # add mocap body to camera to be able to move it around
+    # add body to camera to be able to move it around
     xml = modify_xml_for_camera_movement(xml, camera_name=CAMERA_NAME)
     env.reset_from_xml_string(xml)
     env.sim.reset()
@@ -259,15 +272,27 @@ if __name__ == "__main__":
     camera_id = env.sim.model.camera_name2id(CAMERA_NAME)
     env.viewer.set_camera(camera_id=camera_id)
 
+    # Store camera mover id
+    cam_body_id = env.sim.model.body_name2id("cameramover")
+
+    # Infer initial camera pose
+    if from_tag:
+        initial_file_camera_pos = np.array(cam_tree.get("pos").split(" ")).astype(float)
+        initial_file_camera_quat = T.convert_quat(np.array(cam_tree.get("quat").split(" ")).astype(float), to='xyzw')
+    else:
+        initial_file_camera_pos = np.array(env.sim.model.body_pos[cam_body_id])
+        initial_file_camera_quat = T.convert_quat(np.array(env.sim.model.body_quat[cam_body_id]), to='xyzw')
+    initial_file_camera_pose = T.make_pose(initial_file_camera_pos, T.quat2mat(initial_file_camera_quat))
+
     # remember difference between camera pose in initial tag
     # and absolute camera pose in world
-    initial_world_camera_pos = np.array(env.sim.data.get_mocap_pos("cameramover"))
-    initial_world_camera_quat = T.convert_quat(env.sim.data.get_mocap_quat("cameramover"), to='xyzw')
+    initial_world_camera_pos = np.array(env.sim.model.body_pos[cam_body_id])
+    initial_world_camera_quat = T.convert_quat(env.sim.model.body_quat[cam_body_id], to='xyzw')
     initial_world_camera_pose = T.make_pose(initial_world_camera_pos, T.quat2mat(initial_world_camera_quat))
     world_in_file = initial_file_camera_pose.dot(T.pose_inv(initial_world_camera_pose))
 
     # register callbacks to handle key presses in the viewer
-    key_handler = KeyboardHandler(env=env, camera_id=camera_id)
+    key_handler = KeyboardHandler(env=env, cam_body_id=cam_body_id)
     env.viewer.add_keypress_callback("any", key_handler.on_press)
     env.viewer.add_keyup_callback("any", key_handler.on_release)
     env.viewer.add_keyrepeat_callback("any", key_handler.on_press)
@@ -281,8 +306,8 @@ if __name__ == "__main__":
         spin_count += 1
         if spin_count % 500 == 0:
             # convert from world coordinates to file coordinates (xml subtree)
-            camera_pos = env.sim.data.get_mocap_pos("cameramover")
-            camera_quat = T.convert_quat(env.sim.data.get_mocap_quat("cameramover"), to='xyzw')
+            camera_pos = np.array(env.sim.model.body_pos[cam_body_id])
+            camera_quat = T.convert_quat(env.sim.model.body_quat[cam_body_id], to='xyzw')
             world_camera_pose = T.make_pose(camera_pos, T.quat2mat(camera_quat))
             file_camera_pose = world_in_file.dot(world_camera_pose)
             # TODO: Figure out why numba causes black screen of death (specifically, during mat2pose --> mat2quat call below)

--- a/robosuite/utils/mjcf_utils.py
+++ b/robosuite/utils/mjcf_utils.py
@@ -741,6 +741,28 @@ def sort_elements(root, parent=None, element_filter=None, _elements_dict=None):
     return _elements_dict
 
 
+def find_parent(root, child):
+    """
+    Find the parent element of the specified @child node, recurisvely searching through @root.
+
+    Args:
+        root (ET.Element): Root of the xml element tree to start recursively searching through.
+        child (ET.Element): Child element whose parent is to be found
+
+    Returns:
+        None or ET.Element: Matching parent if found, else None
+    """
+    # Iterate through children (DFS), if the correct child element is found, then return the current root as the parent
+    for r in root:
+        if r == child:
+            return root
+        parent = find_parent(root=r, child=child)
+        if parent is not None:
+            return parent
+    # If we get here, we didn't find anything ):
+    return None
+
+
 def find_elements(root, tags, attribs=None, return_first=True):
     """
     Find all element(s) matching the requested @tag and @attributes. If @return_first is True, then will return the
@@ -748,8 +770,7 @@ def find_elements(root, tags, attribs=None, return_first=True):
     criteria.
 
     Args:
-        root (ET.Element): Root of the xml element tree to start recursively searching through. Default is None
-            (use automatic top-level root in this XML object)
+        root (ET.Element): Root of the xml element tree to start recursively searching through.
         tags (str or list of str or set): Tag(s) to search for in this ElementTree.
         attribs (None or dict of str): Element attribute(s) to check against for a filtered element. A match is
             considered found only if all attributes match. Each attribute key should have a corresponding value with
@@ -778,7 +799,7 @@ def find_elements(root, tags, attribs=None, return_first=True):
             if return_first:
                 return root
             else:
-                elements += root
+                elements.append(root)
     # Continue recursively searching through the element tree
     for r in root:
         if return_first:
@@ -787,7 +808,9 @@ def find_elements(root, tags, attribs=None, return_first=True):
                 return elements
         else:
             found_elements = find_elements(tags=tags, attribs=attribs, root=r, return_first=return_first)
-            elements += found_elements if found_elements else []
+            pre_elements = deepcopy(elements)
+            if found_elements:
+                elements += found_elements if type(found_elements) is list else [found_elements]
 
     return elements if elements else None
 


### PR DESCRIPTION
Resolve #154, now `tune_camera.py` script can handle both inputted camera tags or simply camera names (will initialize cameras to their default sim location), and can also tune nested cameras as well that don't exist at the top worldbody level.