### PR TITLE
Fix contact geoms bug

### DIFF
--- a/robosuite/models/assets/robots/jaco/robot.xml
+++ b/robosuite/models/assets/robots/jaco/robot.xml
@@ -36,7 +36,7 @@
             <body name="j2s7s300_link_0" pos="0 0 0">
                 <inertial pos="0 0 0.05" mass="4" diaginertia="0.4 0.4 0.4" />
                 <geom type="mesh" contype="0" conaffinity="0" group="1" material="carbon_jaco" mesh="base" />
-                <geom type="mesh" material="carbon_jaco" mesh="base" />
+                <geom type="mesh" material="carbon_jaco" mesh="base" name="base_collision"/>
                 <body name="j2s7s300_link_1" pos="0 0 0.15675" quat="0 0 1 0">
                     <inertial pos="0 -0.002 -0.0605" mass="0.7477" diaginertia="0.00152032 0.00152032 0.00059816" />
                     <joint name="j2s7s300_joint_1" pos="0 0 0" axis="0 0 1" limited="true" range="-6.28319 6.28319" damping="0.1" frictionloss="0.01"/>

--- a/robosuite/models/assets/robots/kinova3/robot.xml
+++ b/robosuite/models/assets/robots/kinova3/robot.xml
@@ -27,7 +27,7 @@
             <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
             <!-- mount attached here -->
             <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="1 1 1 1" mesh="base_link" />
-            <geom type="mesh" conaffinity="0" rgba="0.75294 0.75294 0.75294 1" mesh="base_link" />
+            <geom type="mesh" conaffinity="0" rgba="0.75294 0.75294 0.75294 1" mesh="base_link" name="base_collision" />
             <body name="shoulder_link" pos="0 0 0.15643" quat="-3.67321e-06 1 0 0">
                 <inertial pos="-2.3e-05 -0.010364 -0.07336" quat="0.707051 0.0451246 -0.0453544 0.704263" mass="1.3773" diaginertia="0.00488868 0.00457 0.00135132" />
                 <joint name="Actuator1" pos="0 0 0" axis="0 0 1" damping="0.1" />
@@ -63,7 +63,7 @@
                                         <joint name="Actuator7" pos="0 0 0" axis="0 0 1" damping="0.01" />
                                         <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="1 1 1 1" name="b_visual" mesh="bracelet_with_vision_link" />
                                         <geom type="mesh" conaffinity="0" rgba="0.75294 0.75294 0.75294 1" mesh="bracelet_with_vision_link" name="b_collision"/>
-                                        <body name="right_hand" pos="0 0 -0.065" quat="0 0.707105 -0.707108 0 ">
+                                        <body name="right_hand" pos="0 0 -0.065" quat="0 0.707105 -0.707108 0">
                                             <!-- This sites were added for visualization. They are all standardized between models-->
                                             <!-- Position mimics the gripper attachment point (right_hand) -->
                                             <!--  Y-axis should be perpendicular to grasping motion, and Z-axis should point out of the robot eef -->

--- a/robosuite/models/assets/robots/ur5e/robot.xml
+++ b/robosuite/models/assets/robots/ur5e/robot.xml
@@ -32,7 +32,7 @@
             <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
             <!-- mount attached here -->
             <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="0.7 0.7 0.7 1" quat="0.707 0.707 0 0" mesh="base_vis" />
-            <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="base" />
+            <geom type="mesh" rgba="0.7 0.7 0.7 1" mesh="base" name="base_col"/>
             <body name="shoulder_link" pos="0 0 0.163">
                 <inertial pos="0 0 0" mass="3.7" diaginertia="0.0102675 0.0102675 0.00666" />
                 <joint name="shoulder_pan_joint" pos="0 0 0" axis="0 0 1" limited="true" range="-6.28319 6.28319" damping="0.001" frictionloss="0.01" />

--- a/tests/test_robots/test_all_robots.py
+++ b/tests/test_robots/test_all_robots.py
@@ -1,0 +1,30 @@
+"""
+Tests the basic interface of all robots.
+
+This runs some basic sanity checks on the robots, namely, checking that:
+    - Verifies that all single-arm robots have properly defined contact geoms.
+
+Obviously, if an environment crashes during runtime, that is considered a failure as well.
+"""
+from robosuite.robots import ROBOT_CLASS_MAPPING
+from robosuite.robots import SingleArm
+
+
+def test_single_arm_robots():
+    for name, robot in ROBOT_CLASS_MAPPING.items():
+        if robot == SingleArm:
+            print(f'Testing {name}')
+            _test_contact_geoms(robot(name))
+
+
+def _test_contact_geoms(robot):
+    robot.load_model()
+    contact_geoms = robot.robot_model._contact_geoms
+    for geom in contact_geoms:
+        assert isinstance(geom, str), f"The geom {geom} is of type {type(geom)}, but should be {type('placeholder')}"
+    
+    
+if __name__ == "__main__":
+    test_single_arm_robots()
+    print("Robot tests completed.")
+


### PR DESCRIPTION
- Fixed  `contact_geoms` for `Kinova3`, `Jaco` and `UR5e` robot. It is now possible to use these robots with the `Wipe` environment.
- Created a simple test for checking the `contact_geoms`.