### PR TITLE
Fixed default control for orientation in OSC

### DIFF
--- a/robosuite/controllers/osc.py
+++ b/robosuite/controllers/osc.py
@@ -234,7 +234,7 @@ class OperationalSpaceController(Controller):
                 scaled_delta = self.scale_action(delta)
                 if not self.use_ori and set_ori is None:
                     # Set default control for ori since user isn't actively controlling ori
-                    set_ori = np.array([[0, -1., 0.], [-1., 0., 0.], [0., 0., 1.]])
+                    set_ori = np.array([[0., 1., 0.], [1., 0., 0.], [0., 0., -1.]])
             else:
                 scaled_delta = []
         # Else, interpret actions as absolute values
@@ -244,7 +244,7 @@ class OperationalSpaceController(Controller):
             # Set default control for ori if we're only using position control
             if set_ori is None:
                 set_ori = T.quat2mat(T.axisangle2quat(delta[3:6])) if self.use_ori else \
-                    np.array([[0, -1., 0.], [-1., 0., 0.], [0., 0., 1.]])
+                    np.array([[0., 1., 0.], [1., 0., 0.], [0., 0., -1.]])
             # No scaling of values since these are absolute values
             scaled_delta = delta
 


### PR DESCRIPTION
The current default value of [set_ori](https://github.com/ARISE-Initiative/robosuite/blob/2a34f81983877852009b64ec3a7eae7efcffe001/robosuite/controllers/osc.py#L237) has -1 determinant which happens to be an improper rotation.

I noticed that the default eef orientation is pointing in positive z axis. If we need the eef to point down, we should
1. First rotate 180 degrees about the x axis (multiply by Rx(180).
2. Then rotate 90 degrees about the z axis (multiply by Rz(90).

Applying these two transformations to an identity matrix results in the new rotation matrix values included in this PR. 
I've verified the behaviour of the new default orientation on all single armed robot types.

Please find the images attached showing the above transformations.

![default_gripper_orientation_birdview](https://user-images.githubusercontent.com/22681121/119773373-2a804a80-bede-11eb-988d-ba1927a39063.png)
![default_gripper_orientation_frontview](https://user-images.githubusercontent.com/22681121/119773381-2d7b3b00-bede-11eb-9f64-03fe3ee82dc4.png)
![180degree_rotx_gripper_orientation_frontview](https://user-images.githubusercontent.com/22681121/119773396-353adf80-bede-11eb-8406-5e363c272adc.png)
![final_gripper_orientation_frontview](https://user-images.githubusercontent.com/22681121/119773428-3cfa8400-bede-11eb-80b8-bea94cbe73fb.png)

Fixes #230.

