### PR TITLE
Fix Jaco Collision Geoms

### DIFF
--- a/robosuite/models/assets/robots/jaco/robot.xml
+++ b/robosuite/models/assets/robots/jaco/robot.xml
@@ -36,13 +36,13 @@
             <body name="j2s7s300_link_0" pos="0 0 0">
                 <inertial pos="0 0 0.05" mass="4" diaginertia="0.4 0.4 0.4" />
                 <geom type="mesh" contype="0" conaffinity="0" group="1" material="carbon_jaco" mesh="base" />
-                <geom type="mesh" material="carbon_jaco" mesh="base" name="base_collision"/>
+                <geom type="mesh" contype="0" conaffinity="1" material="carbon_jaco" mesh="base" name="base_collision"/>
                 <body name="j2s7s300_link_1" pos="0 0 0.15675" quat="0 0 1 0">
                     <inertial pos="0 -0.002 -0.0605" mass="0.7477" diaginertia="0.00152032 0.00152032 0.00059816" />
                     <joint name="j2s7s300_joint_1" pos="0 0 0" axis="0 0 1" limited="true" range="-6.28319 6.28319" damping="0.1" frictionloss="0.01"/>
                     <geom type="mesh" contype="0" conaffinity="0" group="1" material="carbon_jaco" name="s_visual" mesh="shoulder" />
                     <geom type="mesh" contype="0" conaffinity="0" group="1" material="grey_plastic_jaco" name="s_ring_visual" mesh="ring_big" />
-                    <geom type="mesh" material="carbon_jaco" mesh="shoulder" name="s_collision"/>
+                    <geom type="mesh" contype="0" conaffinity="1" material="carbon_jaco" mesh="shoulder" name="s_collision"/>
                     <body name="j2s7s300_link_2" pos="0 0.0016 -0.11875" quat="0 0 -0.707107 0.707107">
                         <inertial pos="0 -0.103563 0" quat="0.707107 0.707107 0 0" mass="0.8447" diaginertia="0.00247074 0.00247074 0.000380115" />
                         <joint name="j2s7s300_joint_2" pos="0 0 0" axis="0 0 1" limited="true" range="0.820305 5.46288" damping="0.1" frictionloss="0.01"/>


### PR DESCRIPTION
Remove collisions between Jaco base and 1st joint collision geoms to prevent 1st joint from being stuck