### PR TITLE
Fix Joint Velocity Bug

### DIFF
--- a/robosuite/controllers/config/joint_velocity.json
+++ b/robosuite/controllers/config/joint_velocity.json
@@ -4,7 +4,7 @@
   "input_min": -1,
   "output_max": 0.5,
   "output_min": -0.5,
-  "kp": 0.03,
+  "kp": 3.0,
   "velocity_limits": [-1,1],
   "interpolation": null,
   "ramp_ratio": 0.2

--- a/robosuite/controllers/joint_vel.py
+++ b/robosuite/controllers/joint_vel.py
@@ -168,11 +168,8 @@ class JointVelocityController(Controller):
         else:
             self.current_vel = np.array(self.goal_vel)
 
-        # We clip the current joint velocity to be within a reasonable range for stability
-        joint_vel = np.clip(self.joint_vel, self.output_min, self.output_max)
-
         # Compute necessary error terms for PID velocity controller
-        err = self.current_vel - joint_vel
+        err = self.current_vel - self.joint_vel
         derr = err - self.last_err
         self.last_err = err
         self.derr_buf.push(derr)


### PR DESCRIPTION
Fixes #201. Removes the joint velocity observation clipping during the controller computation causing inaccurate results, and increases the default kp gain value for faster convergence.