### PR TITLE
replaced mujoco-py with free-mujoco-py version 2.1.0 from DM

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,14 +3,14 @@
 
 The base installation requires the MuJoCo physics engine (with [mujoco-py](https://github.com/openai/mujoco-py), refer to link for troubleshooting the installation and further instructions) and [numpy](http://www.numpy.org/). To avoid interfering with system packages, it is recommended to install it under a virtual environment by first running `virtualenv -p python3 . && source bin/activate`.
 
-First download MuJoCo 2.0 ([Linux](https://www.roboti.us/download/mujoco200_linux.zip) and [Mac OS X](https://www.roboti.us/download/mujoco200_macos.zip)) and unzip its contents into `~/.mujoco/mujoco200`, and copy your MuJoCo license key `~/.mujoco/mjkey.txt`. You can obtain a license key from [here](https://www.roboti.us/license.html).
+First [download the mujoco binary](https://mujoco.org/download) for your OS and unzip its contents into `~/.mujoco/mujoco210`. There is no license key needed anymore as Mujoco is now free.
    - For Linux, you will need to install some packages to build `mujoco-py` (sourced from [here](https://github.com/openai/mujoco-py/blob/master/Dockerfile), with a couple missing packages added). If using `apt`, the required installation command is:
      ```sh
      $ sudo apt install curl git libgl1-mesa-dev libgl1-mesa-glx libglew-dev \
              libosmesa6-dev software-properties-common net-tools unzip vim \
              virtualenv wget xpra xserver-xorg-dev libglfw3-dev patchelf
      ```
-     Note that for older versions of Ubuntu (e.g., 14.04) there's no libglfw3 package, in which case you need to `export LD_LIBRARY_PATH=$HOME/.mujoco/mujoco200/bin` before proceeding to the next step.
+     Note that for older versions of Ubuntu (e.g., 14.04) there's no libglfw3 package, in which case you need to `export LD_LIBRARY_PATH=$HOME/.mujoco/mujoco210/bin` before proceeding to the next step.
 
 ### Install from pip
 1. After setting up mujoco, robosuite can be installed with

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,7 +1,7 @@
 # Installation
 **robosuite** officially supports Mac OS X and Linux on Python 3. It can be run with an on-screen display for visualization or in a headless mode for model training, with or without a GPU.
 
-The base installation requires the MuJoCo physics engine (with [mujoco-py](https://github.com/openai/mujoco-py), refer to link for troubleshooting the installation and further instructions) and [numpy](http://www.numpy.org/). To avoid interfering with system packages, it is recommended to install it under a virtual environment by first running `virtualenv -p python3 . && source bin/activate`.
+The base installation requires the MuJoCo physics engine (with [mujoco-py](https://github.com/nimrod-gileadi/mujoco-py), refer to link for troubleshooting the installation and further instructions) and [numpy](http://www.numpy.org/). To avoid interfering with system packages, it is recommended to install it under a virtual environment by first running `virtualenv -p python3 . && source bin/activate`.
 
 First [download the mujoco binary](https://mujoco.org/download) for your OS and unzip its contents into `~/.mujoco/mujoco210`. There is no license key needed anymore as Mujoco is now free.
    - For Linux, you will need to install some packages to build `mujoco-py` (sourced from [here](https://github.com/openai/mujoco-py/blob/master/Dockerfile), with a couple missing packages added). If using `apt`, the required installation command is:

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -3,14 +3,13 @@
 
 The base installation requires the MuJoCo physics engine (with [mujoco-py](https://github.com/nimrod-gileadi/mujoco-py), refer to link for troubleshooting the installation and further instructions) and [numpy](http://www.numpy.org/). To avoid interfering with system packages, it is recommended to install it under a virtual environment by first running `virtualenv -p python3 . && source bin/activate`.
 
-First [download the mujoco binary](https://mujoco.org/download) for your OS and unzip its contents into `~/.mujoco/mujoco210`. There is no license key needed anymore as Mujoco is now free.
-   - For Linux, you will need to install some packages to build `mujoco-py` (sourced from [here](https://github.com/openai/mujoco-py/blob/master/Dockerfile), with a couple missing packages added). If using `apt`, the required installation command is:
-     ```sh
-     $ sudo apt install curl git libgl1-mesa-dev libgl1-mesa-glx libglew-dev \
-             libosmesa6-dev software-properties-common net-tools unzip vim \
-             virtualenv wget xpra xserver-xorg-dev libglfw3-dev patchelf
-     ```
-     Note that for older versions of Ubuntu (e.g., 14.04) there's no libglfw3 package, in which case you need to `export LD_LIBRARY_PATH=$HOME/.mujoco/mujoco210/bin` before proceeding to the next step.
+For Linux, you will need to install some packages to build `mujoco-py` (sourced from [here](https://github.com/openai/mujoco-py/blob/master/Dockerfile), with a couple missing packages added). If using `apt`, the required installation command is:
+   ```sh
+   $ sudo apt install curl git libgl1-mesa-dev libgl1-mesa-glx libglew-dev \
+            libosmesa6-dev software-properties-common net-tools unzip vim \
+            virtualenv wget xpra xserver-xorg-dev libglfw3-dev patchelf
+   ```
+   Note that for older versions of Ubuntu (e.g., 14.04) there's no libglfw3 package, in which case you need to `export LD_LIBRARY_PATH=$HOME/.mujoco/mujoco210/bin` before proceeding to the next step.
 
 ### Install from pip
 1. After setting up mujoco, robosuite can be installed with

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.20.0
 numba>=0.52.0
 scipy>=1.2.3
-mujoco-py==2.0.2.13
+free-mujoco-py==2.1.4
 -e .

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "numpy>=1.13.3",
         "numba>=0.49.1",
         "scipy>=1.2.3",
-        "mujoco-py==2.0.2.13",
+        "free-mujoco-py==2.1.4",
     ],
     eager_resources=['*'],
     include_package_data=True,


### PR DESCRIPTION
Updates dependencies for compatibility with new free version of Mujoco. more info: https://github.com/openai/mujoco-py/pull/640. Resolves #262 