### PR TITLE
Switch to use SVL PyBullet release version

### DIFF
--- a/docs/demos.md
+++ b/docs/demos.md
@@ -118,7 +118,7 @@ The `demo_device_control.py` scripts shows how to teleoperate robot with [contro
         Download and install the [driver](https://www.3dconnexion.com/service/drivers.html) before running the script.
 
 Additionally, `--pos_sensitivity` and `--rot_sensitivity` provide relative gains for increasing / decreasing the user input
-device sensitivity. The `--controller` argument determines the choice of using either inverse kinematics controller (`ik`) or operational space controller (`osc`). The main difference is that user inputs with `ik`'s rotations are always taken relative to eef coordinate frame, whereas user inputs with `osc`'s rotations are taken relative to global frame (i.e., static / camera frame of reference). `osc` also tends to be more computationally efficient since `ik` relies on the backend [pybullet](https://github.com/bulletphysics/bullet3) IK solver.
+device sensitivity. The `--controller` argument determines the choice of using either inverse kinematics controller (`ik`) or operational space controller (`osc`). The main difference is that user inputs with `ik`'s rotations are always taken relative to eef coordinate frame, whereas user inputs with `osc`'s rotations are taken relative to global frame (i.e., static / camera frame of reference). `osc` also tends to be more computationally efficient since `ik` relies on the backend [pybullet](https://github.com/StanfordVL/bullet3) IK solver.
 
 
 Furthermore, please choose environment specifics with the following arguments:

--- a/requirements-extra.txt
+++ b/requirements-extra.txt
@@ -1,5 +1,5 @@
 # required for IK controllers
-pybullet==2.6.9
+pybullet-svl>=3.1.6.4
 
 # required for GymWrapper
 gym

--- a/robosuite/controllers/ik.py
+++ b/robosuite/controllers/ik.py
@@ -3,7 +3,7 @@
 
 NOTE: requires pybullet module.
 
-Run `pip install pybullet==2.6.9`.
+Run `pip install "pybullet-svl>=3.1.6.4"`.
 
 
 NOTE: IK is only supported for the following robots:
@@ -19,7 +19,7 @@ Attempting to run IK with any other robot will raise an error!
 try:
     import pybullet as p
 except ImportError:
-    raise Exception("Please make sure pybullet is installed. Run `pip install pybullet==2.6.9`")
+    raise Exception("""Please make sure pybullet is installed. Run `pip install "pybullet-svl>=3.1.6.4"`""")
 import os
 from os.path import join as pjoin
 


### PR DESCRIPTION
The SVL PyBullet version is needed for the iGibson renderer. I also verified that it is compatible with the IK controller. I thus proposed to update our pybullet dependency to this version.