### PR TITLE
bug fix - panda_arm_hand.urdf, panda_arm.xacro have the wrong origin for 'panda_joint1'

### DIFF
--- a/robosuite/models/assets/bullet_data/panda_description/urdf/panda_arm.xacro
+++ b/robosuite/models/assets/bullet_data/panda_description/urdf/panda_arm.xacro
@@ -44,7 +44,7 @@
     </link>
     <joint name="${arm_id}_joint1" type="revolute">
       <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
-      <origin rpy="0 0 0" xyz="0 -0.1 0"/>
+      <origin rpy="0 0 0" xyz="0 0 0.333"/>
       <parent link="${arm_id}_link0"/>
       <child link="${arm_id}_link1"/>
       <axis xyz="0 0 1"/>

--- a/robosuite/models/assets/bullet_data/panda_description/urdf/panda_arm_hand.urdf
+++ b/robosuite/models/assets/bullet_data/panda_description/urdf/panda_arm_hand.urdf
@@ -40,7 +40,7 @@
   </link>
   <joint name="panda_joint1" type="revolute">
     <safety_controller k_position="100.0" k_velocity="40.0" soft_lower_limit="-2.8973" soft_upper_limit="2.8973"/>
-    <origin rpy="0 0 0" xyz="0 -0.1 0"/>
+    <origin rpy="0 0 0" xyz="0 0 0.333"/>
     <parent link="panda_link0"/>
     <child link="panda_link1"/>
     <axis xyz="0 0 1"/>


### PR DESCRIPTION
Hi, 

This pr fixes a bug in 'panda_arm.xacro' and 'panda_arm_hand.urdf' where the xyz value for the 'panda_joint1' joint is wrong. Specifically, the value `<origin rpy="0 0 0" xyz="0 -0.1 0"/>` needs to change to `<origin rpy="0 0 0" xyz="0 0 0.333"/>`. The `0 0 0.333` value is used here as well: https://github.com/ros-planning/moveit_resources/blob/master/panda_description/urdf/panda_arm.xacro#L38

Currently:
![panda-issue](https://user-images.githubusercontent.com/13972782/211708005-44fcf2c6-fddf-43c5-a05f-a871e2a91bb5.png)

With fix:
![panda-issue - fixed](https://user-images.githubusercontent.com/13972782/211708020-25039d27-f474-47a4-82b8-07044a443492.png)

I brought this up previously here: https://github.com/ARISE-Initiative/robosuite/issues/371

Thanks! Let me know if you all need any other info, this is my first pr to this repo so i'm not sure what's expected.