### PR TITLE
fix macro issues from issue #385

### DIFF
--- a/robosuite/__init__.py
+++ b/robosuite/__init__.py
@@ -1,13 +1,3 @@
-try:
-    from robosuite.macros_private import *
-except ImportError:
-    import robosuite
-    from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
-
-    ROBOSUITE_DEFAULT_LOGGER.warn("No private macro file found!")
-    ROBOSUITE_DEFAULT_LOGGER.warn("It is recommended to use a private macro file")
-    ROBOSUITE_DEFAULT_LOGGER.warn("To setup, run: python {}/scripts/setup_macros.py".format(robosuite.__path__[0]))
-
 from robosuite.environments.base import make
 
 # Manipulation environments

--- a/robosuite/devices/keyboard.py
+++ b/robosuite/devices/keyboard.py
@@ -54,7 +54,6 @@ class Keyboard(Device):
         print_command("z-x", "rotate arm about x-axis")
         print_command("t-g", "rotate arm about y-axis")
         print_command("c-v", "rotate arm about z-axis")
-        print_command("ESC", "quit")
         print("")
 
     def _reset_internal_state(self):

--- a/robosuite/devices/spacemouse.py
+++ b/robosuite/devices/spacemouse.py
@@ -120,8 +120,10 @@ class SpaceMouse(Device):
     ):
 
         print("Opening SpaceMouse device")
+        self.vendor_id = vendor_id
+        self.product_id = product_id
         self.device = hid.device()
-        self.device.open(vendor_id, product_id)  # SpaceMouse
+        self.device.open(self.vendor_id, self.product_id)  # SpaceMouse
 
         self.pos_sensitivity = pos_sensitivity
         self.rot_sensitivity = rot_sensitivity
@@ -164,7 +166,6 @@ class SpaceMouse(Device):
         print_command("Move mouse laterally", "move arm horizontally in x-y plane")
         print_command("Move mouse vertically", "move arm vertically")
         print_command("Twist mouse about an axis", "rotate arm about a corresponding axis")
-        print_command("ESC", "quit")
         print("")
 
     def _reset_internal_state(self):
@@ -223,7 +224,7 @@ class SpaceMouse(Device):
             d = self.device.read(13)
             if d is not None and self._enabled:
 
-                if macros.SPACEMOUSE_PRODUCT_ID == 50741:
+                if self.product_id == 50741:
                     ## logic for older spacemouse model
 
                     if d[0] == 1:  ## readings from 6-DoF sensor

--- a/robosuite/macros.py
+++ b/robosuite/macros.py
@@ -36,9 +36,20 @@ MUJOCO_GPU_RENDERING = True
 
 # Spacemouse settings. Used by SpaceMouse class in robosuite/devices/spacemouse.py
 SPACEMOUSE_VENDOR_ID = 9583
-SPACEMOUSE_PRODUCT_ID = 50735
+SPACEMOUSE_PRODUCT_ID = 50734
 
 # If LOGGING LEVEL is set to None, the logger will be turned off
 CONSOLE_LOGGING_LEVEL = "WARN"
 # File logging is written to /tmp/robosuite.log by default
 FILE_LOGGING_LEVEL = "DEBUG"
+
+# Override with macros from macros_private.py file, if it exists
+try:
+    from robosuite.macros_private import *
+except ImportError:
+    import robosuite
+    from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
+
+    ROBOSUITE_DEFAULT_LOGGER.warn("No private macro file found!")
+    ROBOSUITE_DEFAULT_LOGGER.warn("It is recommended to use a private macro file")
+    ROBOSUITE_DEFAULT_LOGGER.warn("To setup, run: python {}/scripts/setup_macros.py".format(robosuite.__path__[0]))


### PR DESCRIPTION
* try to import `macros_private.py` inside `macros.py`
* change the default spacemouse product id from `50735` to `50734`
* remove `ESC` option in `keyboard.py` and `spacemouse.py` -- we never have supported this
* fix bug in `spacemouse.py` when referencing spacemouse product id (use the value specified to constructor rather than the macro value)