### PR TITLE
logging fixes

### DIFF
--- a/robosuite/__init__.py
+++ b/robosuite/__init__.py
@@ -1,8 +1,9 @@
+from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
+
 try:
     from robosuite.macros_private import *
 except ImportError:
     import robosuite
-    from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 
     ROBOSUITE_DEFAULT_LOGGER.warn("No private macro file found!")
     ROBOSUITE_DEFAULT_LOGGER.warn("It is recommended to use a private macro file")

--- a/robosuite/macros.py
+++ b/robosuite/macros.py
@@ -40,5 +40,5 @@ SPACEMOUSE_PRODUCT_ID = 50735
 
 # If LOGGING LEVEL is set to None, the logger will be turned off
 CONSOLE_LOGGING_LEVEL = "WARN"
-# File logging is written to /tmp/robosuite.log by default
-FILE_LOGGING_LEVEL = "DEBUG"
+# File logging is written to /tmp/robosuite_{time}_{pid}.log by default
+FILE_LOGGING_LEVEL = None

--- a/robosuite/utils/log_utils.py
+++ b/robosuite/utils/log_utils.py
@@ -3,6 +3,8 @@ This file contains utility classes and functions for logging to stdout and stder
 Adapted from robomimic: https://github.com/ARISE-Initiative/robomimic/blob/master/robomimic/utils/log_utils.py
 """
 import logging
+import os
+import time
 
 from termcolor import colored
 
@@ -68,7 +70,10 @@ class DefaultLogger:
         logger = logging.getLogger(self.logger_name)
 
         if file_logging_level is not None:
-            fh = logging.FileHandler("/tmp/robosuite.log")
+            time_str = str(time.time()).replace(".", "_")
+            log_file_path = "/tmp/robosuite{}_{}.log".format(time_str, os.getpid())
+            fh = logging.FileHandler(log_file_path)
+            print(colored("[robosuite]: Saving logs to {}".format(log_file_path), "yellow"))
             fh.setLevel(logging.getLevelName(file_logging_level))
             file_formatter = FileFormatter()
             fh.setFormatter(file_formatter)

--- a/robosuite/utils/log_utils.py
+++ b/robosuite/utils/log_utils.py
@@ -71,7 +71,7 @@ class DefaultLogger:
 
         if file_logging_level is not None:
             time_str = str(time.time()).replace(".", "_")
-            log_file_path = "/tmp/robosuite{}_{}.log".format(time_str, os.getpid())
+            log_file_path = "/tmp/robosuite_{}_{}.log".format(time_str, os.getpid())
             fh = logging.FileHandler(log_file_path)
             print(colored("[robosuite]: Saving logs to {}".format(log_file_path), "yellow"))
             fh.setLevel(logging.getLevelName(file_logging_level))


### PR DESCRIPTION
* set unique logging file name: `/tmp/robosuite_{time}_{pid}.log`
* set file logging to `None` by default in `macros.py` (I figured this isn't a critical feature right now)