### PR TITLE
fix Iterable import for python 3.10 in multi_table_arena

### DIFF
--- a/robosuite/models/arenas/multi_table_arena.py
+++ b/robosuite/models/arenas/multi_table_arena.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
- import `Iterable` from the correct module in `robosuite/models/arenas/multi_table_arena.py`
- resolve #355 