### PR TITLE
Minor internal documentation fix

### DIFF
--- a/robosuite/utils/placement_samplers.py
+++ b/robosuite/utils/placement_samplers.py
@@ -187,7 +187,7 @@ class UniformRandomSampler(ObjectPositionSampler):
         Samples the orientation for a given object
 
         Returns:
-            np.array: sampled (r,p,y) euler angle orientation
+            np.array: sampled object quaternion in (w,x,y,z) form
 
         Raises:
             ValueError: [Invalid rotation axis]


### PR DESCRIPTION
Corrected an outdated docstring for _sample_quat() method of UniformRandomSampler. Resolves #413 