### PR TITLE
corrected the last link legth of Kinova Gen3

### DIFF
--- a/robosuite/models/assets/robots/kinova3/robot.xml
+++ b/robosuite/models/assets/robots/kinova3/robot.xml
@@ -63,7 +63,7 @@
                                         <joint name="Actuator7" pos="0 0 0" axis="0 0 1" damping="0.01" />
                                         <geom type="mesh" contype="0" conaffinity="0" group="1" rgba="1 1 1 1" name="b_visual" mesh="bracelet_with_vision_link" />
                                         <geom type="mesh" conaffinity="0" rgba="0.75294 0.75294 0.75294 1" mesh="bracelet_with_vision_link" name="b_collision"/>
-                                        <body name="right_hand" pos="0 0 -0.065" quat="0 0.707105 -0.707108 0">
+                                        <body name="right_hand" pos="0 0 -0.0615" quat="0 0.707105 -0.707108 0">
                                             <!-- This camera points out from the eef. -->
                                             <camera mode="fixed" name="eye_in_hand" pos="0.05 0 0" quat="0 0.707108 0.707108 0" fovy="75"/>
                                             <!-- To add gripper -->


### PR DESCRIPTION
In the [robot.xml](https://github.com/otokatli/robosuite/blob/master/robosuite/models/assets/robots/kinova3/robot.xml) file for Kinova Gen3 robot, there is a minor mistake about the link length of the last link for the robot.

In body `right_hand` the length is defined as 0.65. However, if you check the [Kinova Gen3 manual](https://www.kinovarobotics.com/uploads/User-Guide-Gen3-R07.pdf), on page 199, the link length is defined as 0.615.
