### PR TITLE
`from collections` ➡️ `from collections.abc`

### DIFF
--- a/robosuite/models/arenas/multi_table_arena.py
+++ b/robosuite/models/arenas/multi_table_arena.py
@@ -1,4 +1,4 @@
-from collections import Iterable
+from collections.abc import Iterable
 
 import numpy as np
 


### PR DESCRIPTION
Some of the files in branch v1.4.1 already have the `import Iterable` modified to be compatible with `python 3.10` but this one does not. Updating it.

@otokatli 