### PR TITLE
Support both gym and gymnasium, and retain dict obs in wrapper

### DIFF
--- a/robosuite/wrappers/gym_wrapper.py
+++ b/robosuite/wrappers/gym_wrapper.py
@@ -133,8 +133,6 @@ class GymWrapper(Wrapper, gym.Env):
             np.array: Flattened environment observation space after reset occurs
             dict: Info in GymAPI, default return empty dict
         """
-        import time
-        start_time = time.time()
         if seed is not None:
             if isinstance(seed, int):
                 np.random.seed(seed)

--- a/robosuite/wrappers/gym_wrapper.py
+++ b/robosuite/wrappers/gym_wrapper.py
@@ -5,8 +5,20 @@ interface.
 """
 
 import numpy as np
-import gymnasium as gym
-from gymnasium import spaces, Env
+
+try:
+    import gymnasium as gym
+    from gymnasium import spaces
+except ImportError:
+    # Most APIs between gym and gymnasium are compatible
+    print("WARNING! gymnasium is not installed. We will try to use openai gym instead.")
+    import gym
+    from gym import spaces
+
+    if not gym.__version__ >= '0.26.0':
+        # Due to API Changes in gym>=0.26.0, we need to ensure that the version is correct
+        # Please check: https://github.com/openai/gym/releases/tag/0.26.0
+        raise ImportError("Please ensure version of gym>=0.26.0 to use the GymWrapper.")
 
 from robosuite.wrappers import Wrapper
 
@@ -23,12 +35,14 @@ class GymWrapper(Wrapper, gym.Env):
         keys (None or list of str): If provided, each observation will
             consist of concatenated keys from the wrapped environment's
             observation dictionary. Defaults to proprio-state and object-state.
+        flatten_obs (bool):
+            Whether to flatten the observation dictionary into a 1d array. Defaults to True.
 
     Raises:
         AssertionError: [Object observations must be enabled if no keys]
     """
 
-    def __init__(self, env, keys=None):
+    def __init__(self, env, keys=None, flatten_obs=True):
         # Run super method
         super().__init__(env=env)
         # Create name for gym
@@ -56,12 +70,33 @@ class GymWrapper(Wrapper, gym.Env):
 
         # set up observation and action spaces
         obs = self.env.reset()
-        self.modality_dims = {key: obs[key].shape for key in self.keys}
-        flat_ob = self._flatten_obs(obs)
-        self.obs_dim = flat_ob.size
-        high = np.inf * np.ones(self.obs_dim)
-        low = -high
-        self.observation_space = spaces.Box(low, high)
+
+        # Whether to flatten the observation space
+        self.flatten_obs: bool = flatten_obs
+
+        if self.flatten_obs:
+            flat_ob = self._flatten_obs(obs)
+            self.obs_dim = flat_ob.size
+            high = np.inf * np.ones(self.obs_dim)
+            low = -high
+            self.observation_space = spaces.Box(low, high)
+        else:
+            def get_box_space(sample):
+                """Util fn to obtain the space of a single numpy sample data"""
+                if np.issubdtype(sample.dtype, np.integer):
+                    low = np.iinfo(sample.dtype).min
+                    high = np.iinfo(sample.dtype).max
+                elif np.issubdtype(sample.dtype, np.inexact):
+                    low = float("-inf")
+                    high = float("inf")
+                else:
+                    raise ValueError()
+                return spaces.Box(low=low, high=high, shape=sample.shape, dtype=sample.dtype)
+
+            self.observation_space = spaces.Dict({
+                key: get_box_space(obs[key]) for key in self.keys
+            })
+
         low, high = self.env.action_spec
         self.action_space = spaces.Box(low, high)
 
@@ -84,20 +119,30 @@ class GymWrapper(Wrapper, gym.Env):
                 ob_lst.append(np.array(obs_dict[key]).flatten())
         return np.concatenate(ob_lst)
 
+    def _filter_obs(self, obs_dict) -> dict:
+        """
+        Filters keys of interest out of the observation dictionary, returning a filterd dictionary.
+        """
+        return {key: obs_dict[key] for key in self.keys if key in obs_dict}
+
     def reset(self, seed=None, options=None):
         """
         Extends env reset method to return flattened observation instead of normal OrderedDict and optionally resets seed
 
         Returns:
             np.array: Flattened environment observation space after reset occurs
+            dict: Info in GymAPI, default return empty dict
         """
+        import time
+        start_time = time.time()
         if seed is not None:
             if isinstance(seed, int):
                 np.random.seed(seed)
             else:
                 raise TypeError("Seed must be an integer type!")
         ob_dict = self.env.reset()
-        return self._flatten_obs(ob_dict), {}
+        obs = self._flatten_obs(ob_dict) if self.flatten_obs else self._filter_obs(ob_dict)
+        return obs, {}
 
     def step(self, action):
         """
@@ -116,7 +161,8 @@ class GymWrapper(Wrapper, gym.Env):
                 - (dict) misc information
         """
         ob_dict, reward, terminated, info = self.env.step(action)
-        return self._flatten_obs(ob_dict), reward, terminated, False, info
+        obs = self._flatten_obs(ob_dict) if self.flatten_obs else self._filter_obs(ob_dict)
+        return obs, reward, terminated, False, info
 
     def compute_reward(self, achieved_goal, desired_goal, info):
         """


### PR DESCRIPTION
## Summary

The previously provided `GymWrapper()` only supports the new gymnasium environment. Since there are still many projects that use the classic gym interface, this PR opens up the option for users to use the OpenAI gym interface with robosuite, along with some minor changes.

- The gymnasium and gym interfaces are the same. A runtime check will ensure `gym>=0.26.0` (which uses terminate and truncate).
- The previous implementation flattens all return observations to a single float array. Users can choose to specify `GymWrapper(..., flatten_obs=False)` to retain the dictionary structure in the observation.
- Ensured that the `.observation_space` specifies the correct dtype and shape.

## Quick run

```py
import robosuite as suite
from robosuite.wrappers.gym_wrapper import GymWrapper
import cv2

if __name__ == '__main__':
    # create environment instance
    env = suite.make(
        env_name="Lift",  # try with other tasks like "Stack" and "Door"
        robots="Panda",   # try with other robots like "Sawyer" and "Jaco"
        has_renderer=True,
        has_offscreen_renderer=True,
        use_camera_obs=True,
    )

    # convert to gym/gymnasium environment
    env = GymWrapper(
        env,
        keys=["robot0_proprio-state", "object-state", "agentview_image"],
        flatten_obs=False, # default is True, we will not flatten the observation
    )
    print(" -> action space:", env.action_space)
    print(" -> observation space:", env.observation_space)
    obs, info = env.reset()

    for i in range(1000):
        # action = np.random.randn(env.robots[0].dof)  # sample random action
        action = env.action_space.sample()
        obs, reward, done, trunc, info = env.step(action)  # take action in the environment
        print(obs.keys(), obs["agentview_image"].shape)

        # Optional camera view viz
        cv2.imshow("Agent View", cv2.cvtColor(obs["agentview_image"], cv2.COLOR_RGB2BGR))
        if cv2.waitKey(1) & 0xFF == ord('q'): break

        env.render()  # render on display
```