### PR TITLE
fix gym_wrapper docstring

### DIFF
--- a/robosuite/wrappers/gym_wrapper.py
+++ b/robosuite/wrappers/gym_wrapper.py
@@ -89,7 +89,9 @@ class GymWrapper(Wrapper, gym.Env):
         Extends env reset method to return flattened observation instead of normal OrderedDict and optionally resets seed
 
         Returns:
-            np.array: Flattened environment observation space after reset occurs
+            2-tuple:
+                - (np.array) flattened observations from the environment
+                - (dict) an empty dictionary, as part of the standard return format
         """
         if seed is not None:
             if isinstance(seed, int):


### PR DESCRIPTION
The output type of `reset` of `GymWrapper` didn't match the type on its docstring, so I fixed the docstring instead of removing empty dict (which was gonna result in breaking changes in some demo scripts).