### PR TITLE
Update defusedxml version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "opencv-python",
         "pynput",
         "termcolor",
+        "defusedxml>=0.7.1",
     ],
     eager_resources=["*"],
     include_package_data=True,


### PR DESCRIPTION
This to fix `TypeError: append() argument must be xml.etree.ElementTree.Element, not Element` when calling `python -m robosuite.demos.demo_random_action`
refer to: https://github.com/tiran/defusedxml/issues/43#issuecomment-1739760979