### PR TITLE
add instructions for mac users in docs

### DIFF
--- a/docs/basicusage.md
+++ b/docs/basicusage.md
@@ -3,6 +3,12 @@
 ## Running Standardized Environments
 **robosuite** offers a set of standardized manipulation tasks for benchmarking purposes. These pre-defined environments can be easily instantiated with the `make` function. The APIs we provide to interact with our environments are simple and similar to the ones used by [OpenAI Gym](https://github.com/openai/gym/). Below is a minimalistic example of how to interact with an environment.
 
+<div class="admonition warning">
+<p class="admonition-title">Attention Mac users!</p>
+
+Mac users who wish to use the default mjviewer renderer need to prepend the "python" command with "mj": `mjpython ...`
+</div>
+
 ```python
 import numpy as np
 import robosuite as suite

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -2,6 +2,12 @@
 
 We provide a collection of [demo scripts](https://github.com/ARISE-Initiative/robosuite/tree/master/robosuite/demos) to showcase the functionalities in **robosuite**.
 
+<div class="admonition warning">
+<p class="admonition-title">Attention Mac users!</p>
+
+For these scripts, Mac users who wish to use the default mjviewer renderer need to prepend the "python" command with "mj": `mjpython ...`
+</div>
+
 ### Environment Configuration
 The `demo_random_action.py` script is the starter demo script that you should try first. It highlights the modular design of our simulated environments. It enables users to create new simulation instances by choosing one [environment](modules/environments), one or more [robots](modules/robots), and their [controllers](modules/controllers) from the command line. The script creates an environment instance and controls the robots with uniform random actions drawn from the controller-specific action space. The list of all environments, robots, controllers, and gripper types supported in the current version of **robosuite** are defined by `suite.ALL_ENVIRONMENTS`, `suite.ALL_ROBOTS`, `suite. ALL_PART_CONTROLLERS`, and `suite.ALL_GRIPPERS` respectively.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -17,6 +17,12 @@ The base installation requires the MuJoCo physics engine (with [mujoco](https://
    $ python -m robosuite.demos.demo_random_action
    ```
 
+   <div class="admonition warning">
+   <p class="admonition-title">Attention Mac users!</p>
+
+   Mac users who wish to use the default mjviewer renderer need to prepend the "python" command with "mj": `mjpython ...`
+   </div>
+
 ### Install from source
 
 1. Clone the robosuite repository
@@ -40,6 +46,12 @@ The base installation requires the MuJoCo physics engine (with [mujoco](https://
    ```sh
    $ python robosuite/demos/demo_random_action.py
    ```
+
+   <div class="admonition warning">
+   <p class="admonition-title">Attention Mac users!</p>
+
+   Mac users who wish to use the default mjviewer renderer need to prepend the "python" command with "mj": `mjpython ...`
+   </div>
 
 ### Installing on Windows
 


### PR DESCRIPTION
## What this does
Add an explanation to mac users to prepend the python command with mj, if they're using the mjviewer.
Added to various sections of the introductory docs.

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).