### PR TITLE
fix demo_gym_functionality rendering issues after first ep

### DIFF
--- a/robosuite/demos/demo_gym_functionality.py
+++ b/robosuite/demos/demo_gym_functionality.py
@@ -57,5 +57,5 @@ if __name__ == "__main__":
             if terminated or truncated:
                 print("Episode finished after {} timesteps".format(t + 1))
                 observation, info = env.reset()
-                env.close()
                 break
+        env.close()

--- a/robosuite/wrappers/gym_wrapper.py
+++ b/robosuite/wrappers/gym_wrapper.py
@@ -134,3 +134,9 @@ class GymWrapper(Wrapper, gym.Env):
         """
         # Dummy args used to mimic Wrapper interface
         return self.env.reward()
+
+    def close(self):
+        """
+        wrapper for calling underlying env close function
+        """
+        self.env.close()


### PR DESCRIPTION
## What this does
When running `python robosuite/demos/demo_gym_functionality.py`, the rendering freezes after the first ep. To fix this, we need to run `env.close()` at the end of each ep to re-initialize the renderer for the next ep.

Examples:
```
python robosuite/demos/demo_gym_functionality.py
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).