### PR TITLE
Fix seg demo script

### DIFF
--- a/robosuite/demos/demo_segmentation.py
+++ b/robosuite/demos/demo_segmentation.py
@@ -84,6 +84,7 @@ if __name__ == "__main__":
         camera_segmentations=segmentation_level,
         camera_heights=512,
         camera_widths=512,
+        renderer="mujoco",  # for segmentation
     )
     env.reset()
 


### PR DESCRIPTION
## What this does
Fix seg demo script. For some machines, using the default `renderer=mjviewer` leads to implausible segmentations. Updating to `renderer=mujoco` appears to fix this issue for some machines.


## How it was tested
Explain/show how you tested your changes.

```bash
python robosuite/demos/demo_segmentation.py
```
