### PR TITLE
[fix] fix whole_body_ik config and add a default whole_body_mink_ik config

### DIFF
--- a/robosuite/controllers/config/default/composite/whole_body_mink_ik.json
+++ b/robosuite/controllers/config/default/composite/whole_body_mink_ik.json
@@ -1,14 +1,20 @@
 {
-    "type": "WHOLE_BODY_IK",
+    "type": "WHOLE_BODY_MINK_IK",
     "composite_controller_specific_configs": {
         "ref_name": ["gripper0_right_grip_site", "gripper0_left_grip_site"],
         "interpolation": null,
-        "actuation_part_names": ["torso", "head", "right", "left", "base", "legs"],
+        "actuation_part_names": ["torso", "head", "right", "left"],
         "max_dq": 4,
-        "nullspace_joint_weights": {
-            "robot0_torso_waist_yaw": 100.0,
-            "robot0_torso_waist_pitch": 100.0,
-            "robot0_torso_waist_roll": 500.0,
+        "ik_pseudo_inverse_damping": 5e-2,
+        "ik_integration_dt": 1e-1,
+        "ik_input_type": "absolute",
+        "ik_input_ref_frame": "world",
+        "ik_input_rotation_repr": "axis_angle",
+        "verbose": false,
+        "ik_posture_weights": {
+            "robot0_torso_waist_yaw": 10.0,
+            "robot0_torso_waist_pitch": 10.0,
+            "robot0_torso_waist_roll": 200.0,
             "robot0_l_shoulder_pitch": 4.0,
             "robot0_r_shoulder_pitch": 4.0,
             "robot0_l_shoulder_roll": 3.0,
@@ -16,13 +22,9 @@
             "robot0_l_shoulder_yaw": 2.0,
             "robot0_r_shoulder_yaw": 2.0
         },
-        "ik_pseudo_inverse_damping": 5e-2,
-        "ik_integration_dt": 1e-1,
-        "ik_max_dq": 4.0,
-        "ik_max_dq_torso": 0.2,
-        "ik_input_type": "absolute",
-        "ik_input_rotation_repr": "axis_angle",
-        "verbose": false
+        "ik_hand_pos_cost": 1.0,
+        "ik_hand_ori_cost": 0.5,
+        "use_joint_angle_action_input": false
     },
     "body_parts_controller_configs": {
         "arms": {
@@ -41,7 +43,8 @@
                 "interpolation": null,
                 "ramp_ratio": 0.2,
                 "gripper": {
-                    "type": "GRIP"
+                    "type": "GRIP",
+                    "use_action_scaling": false
                 }
             },
             "left": {
@@ -59,7 +62,8 @@
                 "interpolation": null,
                 "ramp_ratio": 0.2,
                 "gripper": {
-                    "type": "GRIP"
+                    "type": "GRIP",
+                    "use_action_scaling": false
                 }
             }
         },
@@ -83,24 +87,6 @@
             "input_max": 1,
             "input_min": -1,
             "input_type": "absolute",
-            "output_max": 0.5,
-            "output_min": -0.5,
-            "kd": 200,
-            "kv": 200,
-            "kp": 1000,
-            "velocity_limits": [-1,1],
-            "kp_limits": [0, 1000],
-            "interpolation": null,
-            "ramp_ratio": 0.2
-        },
-        "base": {
-            "type" : "JOINT_VELOCITY",
-            "interpolation": null
-        },
-        "legs": {
-            "type": "JOINT_POSITION",
-            "input_max": 1,
-            "input_min": -1,
             "output_max": 0.5,
             "output_min": -0.5,
             "kd": 200,

--- a/robosuite/devices/device.py
+++ b/robosuite/devices/device.py
@@ -212,9 +212,7 @@ class Device(metaclass=abc.ABCMeta):
                     pose_in_base = self.env.robots[0].composite_controller.joint_action_policy.transform_pose(
                         src_frame_pose=pose_in_world,
                         src_frame="world",  # mocap pose is world coordinates
-                        dst_frame=self.env.robots[0].composite_controller.composite_controller_specific_config.get(
-                            "ik_input_ref_frame", "world"
-                        ),
+                        dst_frame=ref_frame,
                     )
                     pos, ori = pose_in_base[:3, 3], pose_in_base[:3, :3]
             else:

--- a/robosuite/examples/third_party_controller/mink_controller.py
+++ b/robosuite/examples/third_party_controller/mink_controller.py
@@ -468,7 +468,9 @@ class WholeBodyMinkIK(WholeBody):
             if weight_name in self.robot_model.joints:
                 valid_posture_weights[weight_name] = ik_posture_weights[weight_name]
             else:
-                ROBOSUITE_DEFAULT_LOGGER.warning(f"Ik posture weight '{weight_name}' does not exist in the robot model. Removing ...")
+                ROBOSUITE_DEFAULT_LOGGER.warning(
+                    f"Ik posture weight '{weight_name}' does not exist in the robot model. Removing ..."
+                )
 
         # Update the configuration with only the valid posture weights
         self.composite_controller_specific_config["ik_posture_weights"] = valid_posture_weights

--- a/robosuite/utils/ik_utils.py
+++ b/robosuite/utils/ik_utils.py
@@ -298,7 +298,7 @@ class IKSolver:
 
         # get the desired joint angles by integrating the desired joint velocities
         self.q_des = self.full_model_data.qpos[self.dof_ids].copy()
-        # mujoco.mj_integratePos(self.full_model, q_des, dq, self.integration_dt)
+        # mujoco.mj_integratePos(self.full_model, self.q_des, self.dq, self.integration_dt)
         self.q_des += self.dq * self.integration_dt  # manually integrate q_des
 
         pre_clip_error = np.inf
@@ -310,9 +310,7 @@ class IKSolver:
             integrated_pos_np = np.array([integrated_pos[site] for site in integrated_pos])
             pre_clip_error = np.linalg.norm(target_pos - integrated_pos_np)
             ROBOSUITE_DEFAULT_LOGGER.info(f"IK error before clipping based on joint ranges: {pre_clip_error}")
-            self.pre_clip_errors.append(pre_clip_error)
-
-        self.debug_iter += 1
+            # self.pre_clip_errors.append(pre_clip_error)
 
         # Set the control signal.
         np.clip(self.q_des, *self.full_model.jnt_range[self.dof_ids].T, out=self.q_des)
@@ -324,4 +322,6 @@ class IKSolver:
             post_clip_error = np.linalg.norm(target_pos - integrated_pos_np)
             ROBOSUITE_DEFAULT_LOGGER.info(f"IK error after clipping based on joint ranges: {post_clip_error}")
 
+        self.debug_iter += 1
+        
         return self.q_des

--- a/robosuite/utils/ik_utils.py
+++ b/robosuite/utils/ik_utils.py
@@ -323,5 +323,5 @@ class IKSolver:
             ROBOSUITE_DEFAULT_LOGGER.info(f"IK error after clipping based on joint ranges: {post_clip_error}")
 
         self.debug_iter += 1
-        
+
         return self.q_des


### PR DESCRIPTION
## What this does
Fix `whole_body_ik` config bug.
Add a default `whole_body_mink_ik` config so that other robots can also use this control mode.

|  Title               | Label           |
|----------------------|-----------------|
| Fixes #549        | (🐛 Bug)        |


## How it was tested
- Set `input_type=absolute` for part controllers in `whole_body_ik`  config
- Copied a GR1 mink IK control config as the default `whole_body_mink_ik` config. A validation function was added for the mink controller to check the keys in the config.

## How to checkout & try? (for the reviewer)
```bash
python robosuite/scripts/collect_human_demonstrations.py --environment Lift --camera frontview --robots Panda --controller WHOLE_BODY_IK

python robosuite/scripts/collect_human_demonstrations.py --environment Lift --camera frontview --robots Panda --controller WHOLE_BODY_MINK_IK
```
