### PR TITLE
Add troubleshooting message for spacemouse failure to open

### DIFF
--- a/robosuite/devices/spacemouse.py
+++ b/robosuite/devices/spacemouse.py
@@ -22,6 +22,7 @@ from collections import namedtuple
 
 import numpy as np
 from pynput.keyboard import Controller, Key, Listener
+
 from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 
 try:

--- a/robosuite/devices/spacemouse.py
+++ b/robosuite/devices/spacemouse.py
@@ -19,6 +19,7 @@ For Linux support, you can find open-source Linux drivers and SDKs online.
 import threading
 import time
 from collections import namedtuple
+from termcolor import colored
 
 import numpy as np
 from pynput.keyboard import Controller, Key, Listener
@@ -128,7 +129,12 @@ class SpaceMouse(Device):
         self.vendor_id = vendor_id
         self.product_id = product_id
         self.device = hid.device()
-        self.device.open(self.vendor_id, self.product_id)  # SpaceMouse
+        try:
+            self.device.open(self.vendor_id, self.product_id)  # SpaceMouse
+        except OSError as e:
+            print("Failed to open SpaceMouse device: ", e)
+            print(colored("Consider killing other processes that may be using the device such as 3DconnexionHelper (killall 3DconnexionHelper)", "yellow"))
+            raise
 
         self.pos_sensitivity = pos_sensitivity
         self.rot_sensitivity = rot_sensitivity

--- a/robosuite/devices/spacemouse.py
+++ b/robosuite/devices/spacemouse.py
@@ -19,10 +19,10 @@ For Linux support, you can find open-source Linux drivers and SDKs online.
 import threading
 import time
 from collections import namedtuple
-from termcolor import colored
 
 import numpy as np
 from pynput.keyboard import Controller, Key, Listener
+from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 
 try:
     import hid
@@ -132,8 +132,10 @@ class SpaceMouse(Device):
         try:
             self.device.open(self.vendor_id, self.product_id)  # SpaceMouse
         except OSError as e:
-            print("Failed to open SpaceMouse device: ", e)
-            print(colored("Consider killing other processes that may be using the device such as 3DconnexionHelper (killall 3DconnexionHelper)", "yellow"))
+            ROBOSUITE_DEFAULT_LOGGER.warning(
+                "Failed to open SpaceMouse device"
+                "Consider killing other processes that may be using the device such as 3DconnexionHelper (killall 3DconnexionHelper)"
+            )
             raise
 
         self.pos_sensitivity = pos_sensitivity


### PR DESCRIPTION
## What this does
Adds helpful error message when SpaceMouse USB device is in use by another process.
Specifically guides users to close `3DconnexionHelper` on macOS, a common cause of device access conflicts.

## How to checkout & try?
1. macOS: Have `3DconnexionHelper` running (reproduces device conflict)
2. Run demo with `--device spacemouse` to see error message