### PR TITLE
Have CI check all `tests/`

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -56,7 +56,4 @@ jobs:
       run: |
         export PYOPENGL_PLATFORM="osmesa"
         export MUJOCO_GL="osmesa"
-        python3 tests/test_robots/test_all_robots.py
-        python3 tests/test_grippers/test_all_grippers.py
-        python3 tests/test_environments/test_all_environments.py
-        pytest tests/test_controllers/test_composite_controllers.py
+        pytest

--- a/tests/test_renderers/test_all_renderers.py
+++ b/tests/test_renderers/test_all_renderers.py
@@ -1,13 +1,17 @@
-"""
-Tests that all renderers are able to render properly.
-"""
+import os
 
 import numpy as np
+import pytest
 
 import robosuite as suite
 from robosuite.controllers import load_composite_controller_config
 
 
+def is_display_available() -> bool:
+    return "DISPLAY" in os.environ or "WAYLAND_DISPLAY" in os.environ
+
+
+@pytest.mark.skipif(not is_display_available(), reason="No display available for on-screen rendering.")
 def test_mujoco_renderer():
     env = suite.make(
         env_name="Lift",
@@ -25,13 +29,13 @@ def test_mujoco_renderer():
 
     low, high = env.action_spec
 
-    # do visualization
     for i in range(10):
         action = np.random.uniform(low, high)
         obs, reward, done, _ = env.step(action)
         env.render()
 
 
+@pytest.mark.skipif(not is_display_available(), reason="No display available for on-screen rendering.")
 def test_mjviewer_renderer():
     env = suite.make(
         env_name="Lift",
@@ -49,7 +53,6 @@ def test_mjviewer_renderer():
 
     low, high = env.action_spec
 
-    # do visualization
     for i in range(10):
         action = np.random.uniform(low, high)
         obs, reward, done, _ = env.step(action)
@@ -72,7 +75,6 @@ def test_offscreen_renderer():
 
     low, high = env.action_spec
 
-    # do visualization
     for i in range(10):
         action = np.random.uniform(low, high)
         obs, reward, done, _ = env.step(action)


### PR DESCRIPTION
Fixes #556 

Rendering test doesn't work properly if no display available. Skip screen rendering tests if no display available.

## How it was tested
`pytest`

