### PR TITLE
simplify composite controller keyword for body_parts

### DIFF
--- a/docs/modules/controllers.rst
+++ b/docs/modules/controllers.rst
@@ -30,7 +30,7 @@ An example of the controller config file is shown below (many parameters are omi
 
         {
         "type": "BASIC",
-        "body_parts_controller_configs": {
+        "body_parts": {
             "arms": {
                 "right": {
                     "type": "OSC_POSE",

--- a/robosuite/controllers/composite/composite_controller_factory.py
+++ b/robosuite/controllers/composite/composite_controller_factory.py
@@ -12,7 +12,7 @@ from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 
 def validate_composite_controller_config(config: dict):
     # Check top-level keys
-    required_keys = ["type", "body_parts_controller_configs"]
+    required_keys = ["type", "body_parts"]
     for key in required_keys:
         if key not in config:
             ROBOSUITE_DEFAULT_LOGGER.error(f"Missing top-level key: {key}")
@@ -32,7 +32,7 @@ def is_part_controller_config(config: Dict):
     """
 
     PART_CONTROLLER_TYPES = ["JOINT_VELOCITY", "JOINT_TORQUE", "JOINT_POSITION", "OSC_POSITION", "OSC_POSE", "IK_POSE"]
-    if "body_parts_controller_configs" not in config and "type" in config:
+    if "body_parts" not in config and "type" in config:
         return config["type"] in PART_CONTROLLER_TYPES
     return False
 
@@ -62,11 +62,11 @@ def refactor_composite_controller_config(controller_config, robot_type, arms):
     else:
         new_controller_config = {}
         new_controller_config["type"] = "BASIC"
-        new_controller_config["body_parts_controller_configs"] = {}
+        new_controller_config["body_parts"] = {}
 
     for arm in arms:
-        new_controller_config["body_parts_controller_configs"][arm] = copy.deepcopy(controller_config)
-        new_controller_config["body_parts_controller_configs"][arm]["gripper"] = {"type": "GRIP"}
+        new_controller_config["body_parts"][arm] = copy.deepcopy(controller_config)
+        new_controller_config["body_parts"][arm]["gripper"] = {"type": "GRIP"}
     return new_controller_config
 
 
@@ -126,14 +126,14 @@ def load_composite_controller_config(controller: Optional[str] = None, robot: Op
         raise
 
     validate_composite_controller_config(composite_controller_config)
-    body_parts_controller_configs = composite_controller_config.pop("body_parts_controller_configs", {})
-    composite_controller_config["body_parts_controller_configs"] = {}
+    body_parts_controller_configs = composite_controller_config.pop("body_parts", {})
+    composite_controller_config["body_parts"] = {}
     for part_name, part_config in body_parts_controller_configs.items():
         if part_name == "arms":
             for arm_name, arm_config in part_config.items():
-                composite_controller_config["body_parts_controller_configs"][arm_name] = arm_config
+                composite_controller_config["body_parts"][arm_name] = arm_config
         else:
-            composite_controller_config["body_parts_controller_configs"][part_name] = part_config
+            composite_controller_config["body_parts"][part_name] = part_config
 
     return composite_controller_config
 

--- a/robosuite/controllers/config/default/composite/basic.json
+++ b/robosuite/controllers/config/default/composite/basic.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/default/composite/hybrid_mobile_base.json
+++ b/robosuite/controllers/config/default/composite/hybrid_mobile_base.json
@@ -1,6 +1,6 @@
 {
     "type": "HYBRID_MOBILE_BASE",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/default/composite/whole_body_ik.json
+++ b/robosuite/controllers/config/default/composite/whole_body_ik.json
@@ -24,7 +24,7 @@
         "ik_input_rotation_repr": "axis_angle",
         "verbose": false
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type" : "JOINT_POSITION",

--- a/robosuite/controllers/config/default/composite/whole_body_mink_ik.json
+++ b/robosuite/controllers/config/default/composite/whole_body_mink_ik.json
@@ -26,7 +26,7 @@
         "ik_hand_ori_cost": 0.5,
         "use_joint_angle_action_input": false
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type" : "JOINT_POSITION",

--- a/robosuite/controllers/config/robots/default_baxter.json
+++ b/robosuite/controllers/config/robots/default_baxter.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_gr1.json
+++ b/robosuite/controllers/config/robots/default_gr1.json
@@ -25,7 +25,7 @@
         "ik_input_rotation_repr": "axis_angle",
         "ik_verbose": true
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type" : "JOINT_POSITION",

--- a/robosuite/controllers/config/robots/default_gr1_fixed_lower_body.json
+++ b/robosuite/controllers/config/robots/default_gr1_fixed_lower_body.json
@@ -26,7 +26,7 @@
         "ik_hand_ori_cost": 0.5,
         "use_joint_angle_action_input": false
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type" : "JOINT_POSITION",

--- a/robosuite/controllers/config/robots/default_gr1_floating_body.json
+++ b/robosuite/controllers/config/robots/default_gr1_floating_body.json
@@ -1,6 +1,6 @@
 {
     "type": "HYBRID_MOBILE_BASE",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_iiwa.json
+++ b/robosuite/controllers/config/robots/default_iiwa.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_kinova3.json
+++ b/robosuite/controllers/config/robots/default_kinova3.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_panda.json
+++ b/robosuite/controllers/config/robots/default_panda.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_panda_dex.json
+++ b/robosuite/controllers/config/robots/default_panda_dex.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_pandaomron.json
+++ b/robosuite/controllers/config/robots/default_pandaomron.json
@@ -1,6 +1,6 @@
 {
     "type": "HYBRID_MOBILE_BASE",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_sawyer.json
+++ b/robosuite/controllers/config/robots/default_sawyer.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_spotwitharm.json
+++ b/robosuite/controllers/config/robots/default_spotwitharm.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_tiago.json
+++ b/robosuite/controllers/config/robots/default_tiago.json
@@ -16,7 +16,7 @@
         "ik_input_rotation_repr": "axis_angle",
         "verbose": false
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/controllers/config/robots/default_tiago_whole_body_ik.json
+++ b/robosuite/controllers/config/robots/default_tiago_whole_body_ik.json
@@ -15,7 +15,7 @@
         "ik_input_rotation_repr": "axis_angle",
         "verbose": false
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type" : "JOINT_POSITION",

--- a/robosuite/controllers/config/robots/default_ur5e.json
+++ b/robosuite/controllers/config/robots/default_ur5e.json
@@ -1,6 +1,6 @@
 {
     "type": "BASIC",
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type": "OSC_POSE",

--- a/robosuite/examples/third_party_controller/default_mink_ik_gr1.json
+++ b/robosuite/examples/third_party_controller/default_mink_ik_gr1.json
@@ -26,7 +26,7 @@
         "ik_hand_ori_cost": 0.5,
         "use_joint_angle_action_input": false
     },
-    "body_parts_controller_configs": {
+    "body_parts": {
         "arms": {
             "right": {
                 "type" : "JOINT_POSITION",

--- a/robosuite/robots/robot.py
+++ b/robosuite/robots/robot.py
@@ -71,9 +71,7 @@ class Robot(object):
         else:
             self.composite_controller_config = load_composite_controller_config(robot=robot_type)
 
-        self.part_controller_config = copy.deepcopy(
-            self.composite_controller_config.get("body_parts_controller_configs", {})
-        )
+        self.part_controller_config = copy.deepcopy(self.composite_controller_config.get("body_parts", {}))
 
         self.gripper = self._input2dict(None)
         self.gripper_type = self._input2dict(gripper_type)
@@ -148,9 +146,7 @@ class Robot(object):
         Remove unused parts that are not in the controller.
         Called by _load_controller() function
         """
-        for part_name, controller_config in self.composite_controller_config.get(
-            "body_parts_controller_configs", {}
-        ).items():
+        for part_name, controller_config in self.composite_controller_config.get("body_parts", {}).items():
             if not self.has_part(part_name):
                 ROBOSUITE_DEFAULT_LOGGER.warn(
                     f'The config has defined for the controller "{part_name}", '

--- a/tests/test_controllers/test_variable_impedance.py
+++ b/tests/test_controllers/test_variable_impedance.py
@@ -56,7 +56,7 @@ def test_variable_impedance():
         np.random.seed(3)
 
         composite_controller_config = load_composite_controller_config(controller=None, robot="Sawyer")
-        controller_config = composite_controller_config["body_parts_controller_configs"]["right"]
+        controller_config = composite_controller_config["body_parts"]["right"]
         controller_config["type"] = controller_name
         # Manually edit impedance settings
         controller_config["impedance_mode"] = "variable"


### PR DESCRIPTION
## What this does
In the composite controller configs, change the keyword from `body_parts_controller_configs` -> `body_parts`. The name is simpler and it unifies the convention between the internal code naming convention and the json files

## How it was tested
Ran `python -m pytest` and everything passed.

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).