### PR TITLE
Fixes #573 🐛

### DIFF
--- a/robosuite/renderers/context/egl_context.py
+++ b/robosuite/renderers/context/egl_context.py
@@ -126,7 +126,7 @@ class EGLGLContext:
                     "required for creating a headless rendering context."
                 )
             atexit.register(EGL.eglTerminate, EGL_DISPLAY)
-        EGL.eglChooseConfig(EGL_DISPLAY, EGL_ATTRIBUTES, config_ptr, config_size, num_configs)
+        EGL.eglChooseConfig(EGL_DISPLAY, EGL_ATTRIBUTES, ctypes.pointer(config_ptr), config_size, num_configs)
         if num_configs.value < 1:
             raise RuntimeError(
                 "EGL failed to find a framebuffer configuration that matches the "


### PR DESCRIPTION
## What this does
This fixes issue #573 which I introduced because I passed the argument `EGLConfig * configs` directly instead of by reference to [`eglChooseConfig`](https://registry.khronos.org/EGL/sdk/docs/man/html/eglChooseConfig.xhtml)

## How it was tested
Ran pytest with python 3.11 and 3.12 and used offscreen rendering while running large deep learning tasks

## How to checkout & try? (for the reviewer)
Use a lot of VRAM with pytorch and try offscreen rendering
