### PR TITLE
osc position fixes

### DIFF
--- a/robosuite/controllers/parts/arm/osc.py
+++ b/robosuite/controllers/parts/arm/osc.py
@@ -256,11 +256,17 @@ class OperationalSpaceController(Controller):
         if self.input_type == "delta":
             scaled_delta = self.scale_action(delta)
             self.goal_pos = self.compute_goal_pos(scaled_delta[0:3])
-            self.goal_ori = self.compute_goal_ori(scaled_delta[3:6])
+            if self.use_ori is True:
+                self.goal_ori = self.compute_goal_ori(scaled_delta[3:6])
+            else:
+                self.goal_ori = self.compute_goal_ori(np.zeros(3))
         # Else, interpret actions as absolute values
         elif self.input_type == "absolute":
             self.goal_pos = action[0:3]
-            self.goal_ori = Rotation.from_rotvec(action[3:6]).as_matrix()
+            if self.use_ori is True:
+                self.goal_ori = Rotation.from_rotvec(action[3:6]).as_matrix()
+            else:
+                self.goal_ori = self.compute_goal_ori(np.zeros(3))
         else:
             raise ValueError(f"Unsupport input_type {self.input_type}")
 


### PR DESCRIPTION
## What this does
This PR should fix https://github.com/ARISE-Initiative/robosuite/issues/562

Running OSC_POSE worked but OSC_POSITION would result in the following error:
```
Traceback (most recent call last):
  File "/archive/tmp/reproduce_v15.py", line 56, in <module>
    obs, reward, done, info = env.step(action)
  File "/home/soroushn/code/robosuite/robosuite/environments/base.py", line 452, in step
    self._pre_action(action, policy_step)
  File "/home/soroushn/code/robosuite/robosuite/environments/robot_env.py", line 589, in _pre_action
    robot.control(robot_action, policy_step=policy_step)
  File "/home/soroushn/code/robosuite/robosuite/robots/fixed_base_robot.py", line 146, in control
    self.composite_controller.set_goal(action)
  File "/home/soroushn/code/robosuite/robosuite/controllers/composite/composite_controller.py", line 103, in set_goal
    controller.set_goal(action)
  File "/home/soroushn/code/robosuite/robosuite/controllers/parts/arm/osc.py", line 263, in set_goal
    self.goal_ori = Rotation.from_rotvec(action[3:6]).as_matrix()
  File "_rotation.pyx", line 1194, in scipy.spatial.transform._rotation.Rotation.from_rotvec
ValueError: Expected `rot_vec` to have shape (3,) or (N, 3), got (0,)
```

Issue was that in osc.py there was no logic to handle cases where we don't want to control orientation. Fixed by adding "zero" delta actions for orientation.  

## How it was tested
Explain/show how you tested your changes.

Ran `pytest` and ran following script adapted from a user:

```
import robosuite as suite
import numpy as np
from robosuite.controllers.composite.composite_controller_factory import refactor_composite_controller_config

arm_controller_config = suite.load_part_controller_config(
    default_controller='OSC_POSITION',
    # default_controller='OSC_POSE',
)

options = {}

options['env_name'] = "Stack" #'Door'
options['robots'] = "Panda" #'UR5e'
robot = options['robots'][0] if isinstance(
    options['robots'], list,
) else options['robots']
options['initialization_noise'] = None
options['controller_configs'] = refactor_composite_controller_config(
    arm_controller_config, robot, ['right', 'left'],
)


# arm_controller_config['control_delta'] = False
print(options['controller_configs']["body_parts"].keys())
options['controller_configs']["body_parts"]["right"]['input_type'] = "absolute"
options['controller_configs']["body_parts"]["right"]['input_ref_frame'] = "world"


env = suite.make(
    **options,
    use_camera_obs=False,  # Set to True if you want camera observations
    has_offscreen_renderer=False,
    has_renderer=True,  # Enable on-screen rendering
    control_freq=200,  # Control frequency in Hz
)

obs = env.reset()
env.viewer.set_camera(camera_id=0)


target_move = 0.1  # 0.1 meters along x-axis
target = obs["robot0_eef_pos"] + np.array([target_move, target_move, target_move])
# target = np.concatenate((obs["robot0_eef_pos"], [2.11110234, 2.18042231, 0.16471495]))
# target = [0.46814484, 0.01100895, 0.10936336, 2.11110234, 2.18042231, 0.16471495]

# Run a few steps to reach the target position
for i in range(1000):

    # # Set desired action in absolute frame
    action = np.zeros(4)
    action[:3] = target
    # action = np.zeros(7)
    # action[:6] = target

    # Send action to the environment
    obs, reward, done, info = env.step(action)

    # Render the environment for visualization
    env.render()


# Close the environment
env.close()
```

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).