### PR TITLE
[fix] fix actuator control with actuator-joint mapping

### DIFF
--- a/robosuite/robots/legged_robot.py
+++ b/robosuite/robots/legged_robot.py
@@ -188,6 +188,10 @@ class LeggedRobot(MobileRobot):
             applied_action_high = self.sim.model.actuator_ctrlrange[self._ref_actuators_indexes_dict[part_name], 1]
             actuator_indexes = self._ref_actuators_indexes_dict[part_name]
             actuator_gears = self.sim.model.actuator_gear[actuator_indexes, 0]
+
+            # select only the joints that are actuated
+            actuated_joint_indexes = self._ref_actuator_to_joint_id[actuator_indexes]
+            applied_action = applied_action[actuated_joint_indexes]
             applied_action = np.clip(applied_action / actuator_gears, applied_action_low, applied_action_high)
             self.sim.data.ctrl[actuator_indexes] = applied_action
 

--- a/robosuite/robots/mobile_robot.py
+++ b/robosuite/robots/mobile_robot.py
@@ -266,6 +266,13 @@ class MobileRobot(Robot):
             self.sim.model.joint_name2id(joint) for joint in self.robot_model.head_joints
         ]
 
+        self._ref_actuator_to_joint_id = np.ones(self.sim.model.nu).astype(np.int32) * (-1)
+        for part_name, actuator_ids in self._ref_actuators_indexes_dict.items():
+            self._ref_actuator_to_joint_id[actuator_ids] = np.array([
+                self._ref_joints_indexes_dict[part_name].index(self.sim.model.actuator_trnid[i, 0])
+                for i in actuator_ids
+            ])
+
     def control(self, action, policy_step=False):
         """
         Actuate the robot with the

--- a/robosuite/robots/robot.py
+++ b/robosuite/robots/robot.py
@@ -130,6 +130,7 @@ class Robot(object):
 
         self._ref_actuators_indexes_dict = {}
         self._ref_joints_indexes_dict = {}
+        self._ref_actuator_to_joint_id = None
 
         self._enabled_parts = {}
         self.composite_controller = None


### PR DESCRIPTION
## What this does
Fix for actuator-to-joint mapping in action handling. Previously, the code didn't properly handle cases where actuator and joint sequences were misaligned or joint count didn't match actuator count due to equality or tendon constraints.
