### PR TITLE
potential fix to build and docs synchronization error

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -35,13 +35,14 @@ jobs:
       run: |
         cd docs
         make clean html
+        mv _build ..
 
     # Deploy to GitHub Pages
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@v3
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
+        publish_dir: _build/html
         destination_dir: docs
     
     # Remove .nojekyll from root directory if it exists


### PR DESCRIPTION
## What this does
When building it looks like documentation pages have an error where the built docs are not the same as what is displayed on the website. For example, the webpage https://robosuite.ai/docs/simulation/device.html is empty despite the https://github.com/ARISE-Initiative/robosuite/blob/master/docs/simulation/device.rst having more information. I suspect this is due to the fact the built docs are being synchronized with the its parent directory: https://github.com/ARISE-Initiative/robosuite/blob/master/.github/workflows/update-docs.yaml#L44

I have updated the workflow to circumvent this issue, but I am not 100% sure if this is the cause/the changes I made are the solution (can't fully test locally).


## How it was tested

Was able to replicate the error by running `rsync -av --delete docs/_build/html/ docs/`  and then `bundle exec jekyll serve` after building the docs and checking out to the `gh_pages` branch. I believe this is what the workflow does under hood.


