### PR TITLE
Adding hdiapi to imports for docs for spacemouse

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -28,7 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install sphinx sphinx_book_theme sphinx_markdown_tables recommonmark nbsphinx sphinx_togglebutton
+        pip install sphinx sphinx_book_theme sphinx_markdown_tables recommonmark nbsphinx sphinx_togglebutton hidapi
 
     # Build the documentation
     - name: Build Docs


### PR DESCRIPTION
## What this does
Adds `hidapi` for rendering spacemouse related documentation under simulation API/devices. Not importing this module could have potentially been what is causing the page to not render correctly.

## How it was tested
I built the website on my Mac and the Spacemouse related information rendered properly with no exception (an exception was thrown earlier and Spacemouse related information did not render).