### PR TITLE
Fix update-docs dependencies

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -28,6 +28,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
+        pip install -r requirements-extra.txt
         pip install sphinx sphinx_book_theme sphinx_markdown_tables recommonmark nbsphinx sphinx_togglebutton
 
     # Build the documentation


### PR DESCRIPTION
## What this does

Device docs not compiling due to missing  dependencies, added dependencies for github action workflow.
