### PR TITLE
Fix device docs - allow imports to continue but log error

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -187,10 +187,3 @@ man_pages = [(master_doc, "robosuite", "robosuite Documentation", [author], 1)]
 texinfo_documents = [
     (master_doc, "robosuite", "robosuite Documentation", author, "robosuite", "ARISE", "Miscellaneous"),
 ]
-
-autodoc_mock_imports = [
-    "robosuite.devices.mjgui",
-    "robosuite.devices.spacemouse",
-    "robosuite.devices.keyboard",
-    "robosuite.devices.device",
-]

--- a/robosuite/devices/keyboard.py
+++ b/robosuite/devices/keyboard.py
@@ -3,10 +3,15 @@ Driver class for Keyboard controller.
 """
 
 import numpy as np
-from pynput.keyboard import Controller, Key, Listener
 
 from robosuite.devices import Device
+from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 from robosuite.utils.transform_utils import rotation_matrix
+
+try:
+    from pynput.keyboard import Key, Listener
+except ImportError as e:
+    ROBOSUITE_DEFAULT_LOGGER.error(f"Failed to import pynput. Error: {e}.")
 
 
 class Keyboard(Device):

--- a/robosuite/devices/spacemouse.py
+++ b/robosuite/devices/spacemouse.py
@@ -21,20 +21,23 @@ import time
 from collections import namedtuple
 
 import numpy as np
-from pynput.keyboard import Controller, Key, Listener
 
 from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 
 try:
     import hid
-except ModuleNotFoundError as exc:
-    raise ImportError(
-        "Unable to load module hid, required to interface with SpaceMouse. "
+except ModuleNotFoundError as e:
+    ROBOSUITE_DEFAULT_LOGGER.error(
+        f"Unable to load module hid, required to interface with SpaceMouse. "
         "Only macOS is officially supported. Install the additional "
-        "requirements with `pip install -r requirements-extra.txt`"
-    ) from exc
+        "requirements with `pip install -r requirements-extra.txt` "
+        f"Error: {e}."
+    )
 
-from pynput.keyboard import Controller, Key, Listener
+try:
+    from pynput.keyboard import Listener
+except ImportError as e:
+    ROBOSUITE_DEFAULT_LOGGER.error(f"Failed to import pynput. Error: {e}.")
 
 import robosuite.macros as macros
 from robosuite.devices import Device


### PR DESCRIPTION
## What this does

Allow imports to continue but log error. Exiting program on error means the docs can't build.