### PR TITLE
Add support to mujoco composite object considering the geom element inside composite does not have "name" attribute

### DIFF
--- a/robosuite/models/base.py
+++ b/robosuite/models/base.py
@@ -40,6 +40,8 @@ class MujocoXML(object):
         self.tendon = self.create_default_element("tendon")
         self.equality = self.create_default_element("equality")
         self.contact = self.create_default_element("contact")
+        self.extension = self.create_default_element("extension")
+        self.compiler = self.create_default_element("compiler")
 
         # Parse any default classes and replace them inline
         default = self.create_default_element("default")

--- a/robosuite/models/objects/objects.py
+++ b/robosuite/models/objects/objects.py
@@ -385,16 +385,17 @@ class MujocoXMLObject(MujocoObject, MujocoXML):
             if not _should_keep(element):
                 parent.remove(element)
             else:
-                g_name = element.get("name")
-                g_name = g_name if g_name is not None else f"g{i}"
-                element.set("name", g_name)
-                # Also optionally duplicate collision geoms if requested (and this is a collision geom)
-                if self.duplicate_collision_geoms and element.get("group") in {None, "0"}:
-                    parent.append(self._duplicate_visual_from_collision(element))
-                    # Also manually set the visual appearances to the original collision model
-                    element.set("rgba", array_to_string(OBJECT_COLLISION_COLOR))
-                    if element.get("material") is not None:
-                        del element.attrib["material"]
+                if parent.tag!="composite":
+                    g_name = element.get("name")
+                    g_name = g_name if g_name is not None else f"g{i}"
+                    element.set("name", g_name)
+                    # Also optionally duplicate collision geoms if requested (and this is a collision geom)
+                    if self.duplicate_collision_geoms and element.get("group") in {None, "0"}:
+                        parent.append(self._duplicate_visual_from_collision(element))
+                        # Also manually set the visual appearances to the original collision model
+                        element.set("rgba", array_to_string(OBJECT_COLLISION_COLOR))
+                        if element.get("material") is not None:
+                            del element.attrib["material"]
         # add joint(s)
         for joint_spec in self.joint_specs:
             obj.append(new_joint(**joint_spec))

--- a/robosuite/utils/mjcf_utils.py
+++ b/robosuite/utils/mjcf_utils.py
@@ -670,6 +670,8 @@ def _element_filter(element, parent):
     # Check for actuator first since this is dependent on the parent element
     if parent is not None and parent.tag == "actuator":
         return "actuators"
+    elif parent is not None and parent.tag == "composite":
+        return "composite_geoms"
     elif element.tag == "joint":
         # Make sure this is not a tendon (this should not have a "joint", "joint1", or "joint2" attribute specified)
         if element.get("joint") is None and element.get("joint1") is None:


### PR DESCRIPTION
## What this does
Inside mujoco composite element, the geom element does not have "name" attribute. Fixed this bug by adding judgement in objects.py and mjcf_utils.py. Also, I added "extension" and "compiler" to MujocoXML class to support mujoco plugin and change default compiler attribute

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Make robosuite support composite object       | (🐛 Bug)        |


## How it was tested
If anyone would like to test this pull request, take a loot at https://github.com/mengqlTHU/robosuite and run tests/test_cables/test_cables.py
![Screenshot from 2025-01-14 15-21-51](https://github.com/user-attachments/assets/fabfc76c-4fc1-426e-b734-ac0ebad435b0)

