### PR TITLE
Replace warn with warning

### DIFF
--- a/robosuite/macros.py
+++ b/robosuite/macros.py
@@ -50,6 +50,6 @@ except ImportError:
     import robosuite
     from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 
-    ROBOSUITE_DEFAULT_LOGGER.warn("No private macro file found!")
-    ROBOSUITE_DEFAULT_LOGGER.warn("It is recommended to use a private macro file")
-    ROBOSUITE_DEFAULT_LOGGER.warn("To setup, run: python {}/scripts/setup_macros.py".format(robosuite.__path__[0]))
+    ROBOSUITE_DEFAULT_LOGGER.warning("No private macro file found!")
+    ROBOSUITE_DEFAULT_LOGGER.warning("It is recommended to use a private macro file")
+    ROBOSUITE_DEFAULT_LOGGER.warning("To setup, run: python {}/scripts/setup_macros.py".format(robosuite.__path__[0]))

--- a/robosuite/robots/robot.py
+++ b/robosuite/robots/robot.py
@@ -148,7 +148,7 @@ class Robot(object):
         """
         for part_name, controller_config in self.composite_controller_config.get("body_parts", {}).items():
             if not self.has_part(part_name):
-                ROBOSUITE_DEFAULT_LOGGER.warn(
+                ROBOSUITE_DEFAULT_LOGGER.warning(
                     f'The config has defined for the controller "{part_name}", '
                     "but the robot does not have this component. Skipping, but make sure this is intended."
                     f"Removing the controller config for {part_name} from self.part_controller_config."
@@ -510,7 +510,7 @@ class Robot(object):
             zip(self.sim.data.qpos[self._ref_joint_pos_indexes], self.sim.model.jnt_range[self._ref_joint_indexes])
         ):
             if q_limits[0] != q_limits[1] and not (q_limits[0] + tolerance < q < q_limits[1] - tolerance):
-                ROBOSUITE_DEFAULT_LOGGER.warn("Joint limit reached in joint " + str(qidx))
+                ROBOSUITE_DEFAULT_LOGGER.warning("Joint limit reached in joint " + str(qidx))
                 return True
         return False
 


### PR DESCRIPTION
Fix the the following warning message:

robosuite/robosuite/robots/robot.py:151: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead