### PR TITLE
fix the mounting direction of dex hand for panda robot

### DIFF
--- a/robosuite/models/robots/compositional.py
+++ b/robosuite/models/robots/compositional.py
@@ -87,7 +87,7 @@ class PandaDexRH(Panda):
 
     @property
     def gripper_mount_quat_offset(self):
-        return {"right": [0.5, -0.5, 0.5, 0.5]}
+        return {"right": [-0.5, 0.5, 0.5, -0.5]}
 
 
 class PandaDexLH(Panda):
@@ -101,4 +101,4 @@ class PandaDexLH(Panda):
 
     @property
     def gripper_mount_quat_offset(self):
-        return {"right": [0.5, -0.5, 0.5, 0.5]}
+        return {"right": [0.5, -0.5, 0.5, -0.5]}


### PR DESCRIPTION
## What this does
Change the mounting direction for PandaDexHR and PandaDexHL, previously the fingers are pointing forward. Now the hand is pointing downward.