### PR TITLE
Standardizing End-Effector Frame Conventions for  Robot-Gripper Compatibility

### DIFF
--- a/robosuite/models/assets/grippers/bd_gripper.xml
+++ b/robosuite/models/assets/grippers/bd_gripper.xml
@@ -44,11 +44,11 @@
   </default>
 
   <worldbody>
-    <body name="right_gripper" pos="0 0 0" quat="1 0 0 0">
+    <body name="right_gripper" pos="0 0 -0.05" quat="0 0.707107 0 0.707107">
         <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 1" type="sphere" group="1"/>
         <inertial pos="0 0 0.0" quat="0.707107 0.707107 0 0" mass="0.3" diaginertia="0.09 0.07 0.05" />
         <!-- This site was added for visualization. -->
-        <body name="eef" pos="0 0 0.0" quat="0.707 0. -0.707 0.">
+        <body name="eef" pos="0.2 0 0" quat="0.5 0.5 0.5 0.5">
             <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="0 0 1 0.5" type="sphere" group="1"/>
             <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
             <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>

--- a/robosuite/models/assets/grippers/fourier_left_hand.xml
+++ b/robosuite/models/assets/grippers/fourier_left_hand.xml
@@ -65,10 +65,10 @@
   </asset>
 
   <worldbody>
-    <body name="left_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
+    <body name="left_hand" pos="0 0 0" quat="0.5 -0.5 0.5 -0.5">
       <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
       <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
-      <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
+      <body name="eef" pos="0 0 0" quat="0.707107 0.707107 0 0">
           <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
           <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
           <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>

--- a/robosuite/models/assets/grippers/fourier_left_hand.xml
+++ b/robosuite/models/assets/grippers/fourier_left_hand.xml
@@ -74,7 +74,7 @@
           <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
           <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
           <!-- This site was added for visualization. -->
-          <site name="grip_site_cylinder" pos="0 0 0" rgba="0 1 0 0.3" type="cylinder" group="1"/>
+          <site name="grip_site_cylinder" pos="0 0 0" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
       </body>
 
       <!-- Palm  -->

--- a/robosuite/models/assets/grippers/fourier_left_hand.xml
+++ b/robosuite/models/assets/grippers/fourier_left_hand.xml
@@ -65,16 +65,16 @@
   </asset>
 
   <worldbody>
-    <body name="left_hand" pos="0 0 0" quat="0.7071068 0.7071068 0 0">
+    <body name="left_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
       <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
       <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
-      <body name="eef" pos="0 0 0" quat="0.707 0. -0.707 0.">
+      <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
           <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
           <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
           <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
           <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
           <!-- This site was added for visualization. -->
-          <site name="grip_site_cylinder" pos="0 0 0" quat="-0.5 -0.5 -0.5 0.5" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
+          <site name="grip_site_cylinder" pos="0 0 0" rgba="0 1 0 0.3" type="cylinder" group="1"/>
       </body>
 
       <!-- Palm  -->

--- a/robosuite/models/assets/grippers/fourier_right_hand.xml
+++ b/robosuite/models/assets/grippers/fourier_right_hand.xml
@@ -78,10 +78,10 @@
   </asset>
 
   <worldbody>
-    <body name="right_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
+    <body name="right_hand" pos="0 0 0" quat="0.5 -0.5 -0.5 0.5">
       <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
       <!-- <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/> -->
-      <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
+      <body name="eef" pos="0 0 0" quat="0.707107 0.707107 0 0">
           <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
           <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
           <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>

--- a/robosuite/models/assets/grippers/fourier_right_hand.xml
+++ b/robosuite/models/assets/grippers/fourier_right_hand.xml
@@ -78,16 +78,16 @@
   </asset>
 
   <worldbody>
-    <body name="right_hand" pos="0 0 0" quat="0.7071068 0.7071068 0 0">
+    <body name="right_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
       <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
       <!-- <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/> -->
-      <body name="eef" pos="0 0 0" quat="0.707 0. -0.707 0.">
+      <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
           <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
           <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
           <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
           <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
           <!-- This site was added for visualization. -->
-          <site name="grip_site_cylinder" pos="0 0 0" quat="-0.5 -0.5 -0.5 0.5" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
+          <site name="grip_site_cylinder" pos="0 0 0" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
       </body>
 
       <!-- Palm -->

--- a/robosuite/models/assets/grippers/inspire_left_hand.xml
+++ b/robosuite/models/assets/grippers/inspire_left_hand.xml
@@ -75,14 +75,14 @@
     </asset>
 
     <worldbody>
-        <body name="left_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
+        <body name="left_hand" pos="0 0 0" quat="0.5 -0.5 0.5 -0.5">
             <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
             <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
-            <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
-                <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
+            <body name="eef" pos="0 0 0" quat="0.707107 0.707107 0 0">
+                <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 0" type="sphere" group="2"/>
                 <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
                 <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
-                <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
+                <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 1" type="cylinder" group="1"/>
                 <!-- This site was added for visualization. -->
                 <site name="grip_site_cylinder" pos="0 0 0" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
             </body>

--- a/robosuite/models/assets/grippers/inspire_left_hand.xml
+++ b/robosuite/models/assets/grippers/inspire_left_hand.xml
@@ -75,16 +75,16 @@
     </asset>
 
     <worldbody>
-        <body name="left_hand" pos="0 0 0" quat="0.7071068 0.7071068 0 0">
+        <body name="left_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
             <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
             <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
-            <body name="eef" pos="0 0 0" quat="0.707 0. -0.707 0.">
+            <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
                 <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
                 <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
                 <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
                 <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
                 <!-- This site was added for visualization. -->
-                <site name="grip_site_cylinder" pos="0 0 0" quat="-0.5 -0.5 -0.5 0.5" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
+                <site name="grip_site_cylinder" pos="0 0 0" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
             </body>
 
 

--- a/robosuite/models/assets/grippers/inspire_right_hand.xml
+++ b/robosuite/models/assets/grippers/inspire_right_hand.xml
@@ -72,10 +72,10 @@
     </asset>
 
     <worldbody> 
-        <body name="right_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
+        <body name="right_hand" pos="0 0 0" quat="0.5 -0.5 -0.5 0.5">
             <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
             <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
-            <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
+            <body name="eef" pos="0 0 0" quat="0.707107 0.707107 0 0">
                 <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
                 <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
                 <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>

--- a/robosuite/models/assets/grippers/inspire_right_hand.xml
+++ b/robosuite/models/assets/grippers/inspire_right_hand.xml
@@ -72,16 +72,16 @@
     </asset>
 
     <worldbody> 
-        <body name="right_hand" pos="0 0 0" quat="0.7071068 0.7071068 0 0">
+        <body name="right_hand" pos="0 0 0" quat="0.707107 -0.707107 0 0">
             <site name="ft_frame" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 0 0 0" type="sphere" group="1"/>
             <inertial diaginertia="0 0 0" mass="0" pos="0 0 0"/>
-            <body name="eef" pos="0 0 0" quat="0.707 0. -0.707 0.">
+            <body name="eef" pos="0 0 0" quat="0.5 0.5 0.5 -0.5">
                 <site name="grip_site" pos="0 0 0" size="0.01 0.01 0.01" rgba="1 1 0 1" type="sphere" group="2"/>
                 <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
                 <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
                 <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
                 <!-- This site was added for visualization. -->
-                <site name="grip_site_cylinder" pos="0 0 0" quat="-0.5 -0.5 -0.5 0.5" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
+                <site name="grip_site_cylinder" pos="0 0 0" size="0.005 0.5" rgba="0 1 0 0.3" type="cylinder" group="1"/>
             </body>
 
 

--- a/robosuite/models/assets/robots/gr1/robot.xml
+++ b/robosuite/models/assets/robots/gr1/robot.xml
@@ -139,9 +139,13 @@
 															<site name="r_wrist_site" pos="0 0 0" size="0.03 0.03 0.03" rgba="1 0 0 0" type="sphere" group="1" />
 															<inertial pos="0.0060733 0.0018907 -0.084578" quat="0.647336 -0.27161 -0.257721 0.6639" mass="0.53221" diaginertia="0.000319947 0.000196296 0.000182477" />
 															<joint name="r_wrist_pitch" pos="0 0 0" axis="0.0 1.0 0.0" range="-1.5 1.5" />
-															<body name="right_eef" pos="0 0 0" quat="-0.707107 0 0 0.707107">
+															<body name="right_eef" pos="0 0 0" quat="0 1 0 0">
 																
-																
+                                                                <!-- These sites were added for visualization. -->
+                                                                <site name="right_ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
+                                                                <site name="right_ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
+                                                                <site name="right_ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
+
 																<body name="right_mount" quat="0 0 1 0" />
 																<body name="right_hand_eef" pos="0 0 0" />
 																<camera mode="fixed" name="eye_in_right_hand" pos="-0.05 0.15 0.0" quat="0.965926 -0.258819 0.000000 0.000000" fovy="75" />
@@ -192,7 +196,12 @@
 															<joint name="l_wrist_pitch" pos="0 0 0" axis="0.0 1.0 0.0" range="-1.5 1.5" />
 															<site name="l_wrist_site" pos="0 0 0" size="0.03 0.03 0.03" rgba="1 0 0 0" type="sphere" group="1" />
 															<inertial pos="0.0071289 -0.0026192 -0.078567" quat="0.298548 0.646339 0.631172 0.307795" mass="0.5239" diaginertia="0.000345825 0.000211684 0.000195941" />
-															<body name="left_eef" pos="0 0 0" quat="0.707107 0 0 0.707107">
+															<body name="left_eef" pos="0 0 0" quat="0 1 0 0">
+																<!-- These sites were added for visualization. -->
+                                                                <site name="left_ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
+                                                                <site name="left_ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
+                                                                <site name="left_ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
+
 																<site name="left_eef_site" pos="0 0 0" size="0.01" rgba="1 0.3 0.3 1" group="2" />
 																<body name="left_mount" quat="0 0 1 0" />
 																<body name="left_hand_eefd" pos="0 0 0" />

--- a/robosuite/models/assets/robots/panda/robot.xml
+++ b/robosuite/models/assets/robots/panda/robot.xml
@@ -220,6 +220,10 @@
                       <geom type="mesh" group="0" mesh="link7" name="link7_collision"/>
                       <body name="right_hand" pos="0 0 0.1065" quat="0.924 0 0 -0.383">
                         <inertial pos="0 0 0" mass="0.5" diaginertia="0.05 0.05 0.05"/>
+                        <!-- These sites were added for visualization. -->
+                        <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
+                        <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
+                        <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
                         <!-- This camera points out from the eef. -->
                         <camera mode="fixed" name="eye_in_hand" pos="0.05 0 0" quat="0 0.707108 0.707108 0" fovy="75"/>
                         <!-- to add gripper -->

--- a/robosuite/models/assets/robots/spot_arm/robot.xml
+++ b/robosuite/models/assets/robots/spot_arm/robot.xml
@@ -94,7 +94,11 @@
                       diaginertia="0.00176281 0.00168181 0.000767414"/>
                     <joint name="arm_wr1" axis="1 0 0" range="-2.87979 2.87979"/>
                     <!--Start of right_hand-->
-                    <body name="right_hand" pos="0.0 0.0 0.0" quat="1 0 0 0">
+                    <body name="right_hand" pos="0.05 0.0 0.0" quat="0 0.707107 0 0.707107">
+                        <!-- These sites are used for visualization only -->
+                        <site name="ee_x" pos="0.1 0 0" size="0.005 .1"  quat="0.707105  0 0.707108 0 " rgba="1 0 0 0" type="cylinder" group="1"/>
+                        <site name="ee_y" pos="0 0.1 0" size="0.005 .1" quat="0.707105 0.707108 0 0" rgba="0 1 0 0" type="cylinder" group="1"/>
+                        <site name="ee_z" pos="0 0 0.1" size="0.005 .1" quat="1 0 0 0" rgba="0 0 1 0" type="cylinder" group="1"/>
                         <camera mode="fixed" name="right_eye_in_hand" pos="0.05 0 0" quat="0.5 0.5 -0.5 -0.5" fovy="75"/>
                     </body>
                   </body>

--- a/robosuite/models/robots/compositional.py
+++ b/robosuite/models/robots/compositional.py
@@ -81,13 +81,13 @@ class PandaDexRH(Panda):
     def default_gripper(self):
         return {"right": "InspireRightHand"}
 
-    @property
-    def gripper_mount_pos_offset(self):
-        return {"right": [0.0, 0.0, 0.0]}
+    # @property
+    # def gripper_mount_pos_offset(self):
+    #     return {"right": [0.0, 0.0, 0.0]}
 
-    @property
-    def gripper_mount_quat_offset(self):
-        return {"right": [0.5, -0.5, -0.5, 0.5]}
+    # @property
+    # def gripper_mount_quat_offset(self):
+    #     return {"right": [0.5, -0.5, -0.5, 0.5]}
 
 
 class PandaDexLH(Panda):
@@ -95,10 +95,10 @@ class PandaDexLH(Panda):
     def default_gripper(self):
         return {"right": "InspireLeftHand"}
 
-    @property
-    def gripper_mount_pos_offset(self):
-        return {"right": [0.0, 0.0, 0.0]}
+    # @property
+    # def gripper_mount_pos_offset(self):
+    #     return {"right": [0.0, 0.0, 0.0]}
 
-    @property
-    def gripper_mount_quat_offset(self):
-        return {"right": [0.5, -0.5, 0.5, -0.5]}
+    # @property
+    # def gripper_mount_quat_offset(self):
+    #     return {"right": [0.5, -0.5, 0.5, -0.5]}

--- a/robosuite/models/robots/compositional.py
+++ b/robosuite/models/robots/compositional.py
@@ -87,7 +87,7 @@ class PandaDexRH(Panda):
 
     @property
     def gripper_mount_quat_offset(self):
-        return {"right": [-0.5, 0.5, 0.5, -0.5]}
+        return {"right": [0.5, -0.5, -0.5, 0.5]}
 
 
 class PandaDexLH(Panda):


### PR DESCRIPTION
**Issue:**
Current code shows misaligned gripper mounting orientations, requiring custom gripper_mount_pose adjustments for different robot-gripper combinations.

<img width="368" alt="51737573992_ pic" src="https://github.com/user-attachments/assets/c4005179-430f-4bf6-8ce5-af28d496c7d3" />
<img width="404" alt="61737574544_ pic" src="https://github.com/user-attachments/assets/9bd77130-4e9e-4c61-9ca2-518ddec9bc9b" />

**Proposed frame convention:**

Robot end-effector frame:
- Z: gripper mounting direction
- Y: lateral direction
- X: Y × Z

<img width="355" alt="111737593724_ pic" src="https://github.com/user-attachments/assets/d258f28c-5e01-49c8-afd3-dd0743c5732f" />
<img width="429" alt="121737597215_ pic" src="https://github.com/user-attachments/assets/b45ee87a-e1f2-4ed5-9436-195e1916888f" />


Gripper frame:
- Z: mounting direction (aligned with robot Z)
- X: Palm normal/grasp axis
- Y: Z × X
- 
<img width="355" alt="91737589932_ pic" src="https://github.com/user-attachments/assets/4ca4a58c-243c-4d2a-a1c1-087eece69946" />
<img width="428" alt="211737614400_ pic" src="https://github.com/user-attachments/assets/dd19567e-9928-4949-b0f6-b9045de423af" />

It makes all robot end-effector and gripper base frames consistent, enabling plug-and-play gripper changes without pose adjustments. Also eliminates the need for custom `gripper_mount_quat_offset` configurations for PandaDexLH and PandaDexRH.

More examples:
<img width="360" alt="171737613331_ pic" src="https://github.com/user-attachments/assets/df5412f1-79f5-4b2c-86aa-3b84af2ff9c4" />
<img width="360" alt="181737613355_ pic" src="https://github.com/user-attachments/assets/7af1a0e2-6704-4997-a13d-95fcbb4d233c" />

<img width="360" alt="191737613525_ pic" src="https://github.com/user-attachments/assets/3b858b98-deef-43a8-a802-f1ae8dc92633" />
<img width="360" alt="201737613737_ pic" src="https://github.com/user-attachments/assets/8eaad618-e79c-4836-8788-ba27c86c2a41" />


PS: We'd better add some unit tests to verify frame consistency in new end-effector integrations.