### PR TITLE
fix pot with handles when pot is rectangle

### DIFF
--- a/robosuite/models/objects/composite/pot_with_handles.py
+++ b/robosuite/models/objects/composite/pot_with_handles.py
@@ -169,7 +169,7 @@ class PotWithHandlesObject(CompositeObject):
             [-(self.body_half_size[1] - self.thickness / 2), 0, self.body_half_size[1] - self.thickness / 2, 0]
         )
         w_vals = np.array(
-            [self.body_half_size[1], self.body_half_size[0], self.body_half_size[1], self.body_half_size[0]]
+            [self.body_half_size[0], self.body_half_size[1], self.body_half_size[0], self.body_half_size[1]]
         )
         r_vals = np.array([np.pi / 2, 0, -np.pi / 2, np.pi])
         for i, (x, y, w, r) in enumerate(zip(x_off, y_off, w_vals, r_vals)):


### PR DESCRIPTION
The current pot_with_handles object will result in a wrong shape when `size[0] != size[1]` One line change can fix this. 