### PR TITLE
PyPI Publishing GitHub Action

### DIFF
--- a/.github/workflows/update-pypi.yaml
+++ b/.github/workflows/update-pypi.yaml
@@ -57,7 +57,7 @@ jobs:
     - name: Download all the dists
       uses: actions/download-artifact@v4
       with:
-        name: python-package-distributions
+        name: release-dists
         path: dist/
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/update-pypi.yaml
+++ b/.github/workflows/update-pypi.yaml
@@ -1,0 +1,64 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+  
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    # Checkout the repository
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    # Set up Python environment
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
+
+    # Install dependencies
+    - name: Build release distribution
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install build
+        python -m build
+
+    - name: Store the distribution packages
+      uses: actions/upload-artifact@v4
+      with:
+        name: release-dists
+        path: dist/
+
+  publish-to-testpypi:
+    name: Publish Python distribution to TestPyPI
+    needs:
+    - build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/robosuite/
+
+    permissions:
+      id-token: write  # IMPORTANT: mandatory for trusted publishing
+
+    steps:
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+

--- a/.github/workflows/update-pypi.yaml
+++ b/.github/workflows/update-pypi.yaml
@@ -62,5 +62,5 @@ jobs:
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist/
 

--- a/.github/workflows/update-pypi.yaml
+++ b/.github/workflows/update-pypi.yaml
@@ -2,7 +2,9 @@ name: Publish to PyPI
 
 on:
   workflow_dispatch:
-  
+  push:
+    branches:
+      - 'pypi-action'
   release:
     types: [published]
 

--- a/.github/workflows/update-pypi.yaml
+++ b/.github/workflows/update-pypi.yaml
@@ -54,7 +54,7 @@ jobs:
       id-token: write  # IMPORTANT: mandatory for trusted publishing
 
     steps:
-    - name: Download all the dists
+    - name: Download the dists
       uses: actions/download-artifact@v4
       with:
         name: release-dists

--- a/.github/workflows/update-pypi.yaml
+++ b/.github/workflows/update-pypi.yaml
@@ -62,5 +62,5 @@ jobs:
     - name: Publish distribution to TestPyPI
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        packages-dir: dist/
+        repository-url: https://test.pypi.org/legacy/
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     author="Yuke Zhu",
     url="https://github.com/ARISE-Initiative/robosuite",
     author_email="yukez@cs.utexas.edu",
-    version="1.5.0",
+    version="1.5.1",
     long_description=long_description,
     long_description_content_type="text/markdown",
 )


### PR DESCRIPTION
Adds a CI/CD action for updating PyPI. This is currently for test PyPI. The action will run in any of the following three cases:
1. When a new commit is pushed to the PyPI branch (for testing purposes)
2. When the workflow is manually triggered
3. When a new release is published 