### PR TITLE
Make robot initial pose seedable

### DIFF
--- a/robosuite/environments/robot_env.py
+++ b/robosuite/environments/robot_env.py
@@ -345,7 +345,7 @@ class RobotEnv(MujocoEnv):
             # Create sensor information
             sensors = []
             names = []
-            for (cam_name, cam_w, cam_h, cam_d, cam_segs) in zip(
+            for cam_name, cam_w, cam_h, cam_d, cam_segs in zip(
                 self.camera_names,
                 self.camera_widths,
                 self.camera_heights,
@@ -523,7 +523,7 @@ class RobotEnv(MujocoEnv):
 
         # Reset robot and update action space dimension along the way
         for robot in self.robots:
-            robot.reset(deterministic=self.deterministic_reset)
+            robot.reset(deterministic=self.deterministic_reset, rng=self.rng)
             self._action_dim += robot.action_dim
 
         # Update cameras if appropriate

--- a/robosuite/robots/fixed_base_robot.py
+++ b/robosuite/robots/fixed_base_robot.py
@@ -66,16 +66,17 @@ class FixedBaseRobot(Robot):
         # First, run the superclass method to load the relevant model
         super().load_model()
 
-    def reset(self, deterministic=False):
+    def reset(self, deterministic=False, rng=None):
         """
         Sets initial pose of arm and grippers. Overrides gripper joint configuration if we're using a
         deterministic reset (e.g.: hard reset from xml file)
 
         Args:
             deterministic (bool): If true, will not randomize initializations within the sim
+            rng (numpy.random._generator.Generator): Seeded random number generator
         """
         # First, run the superclass method to reset the position and controller
-        super().reset(deterministic)
+        super().reset(deterministic, rng)
 
     def setup_references(self):
         """

--- a/robosuite/robots/legged_robot.py
+++ b/robosuite/robots/legged_robot.py
@@ -117,16 +117,17 @@ class LeggedRobot(MobileRobot):
         # First, run the superclass method to load the relevant model
         super().load_model()
 
-    def reset(self, deterministic=False):
+    def reset(self, deterministic=False, rng=None):
         """
         Sets initial pose of arm and grippers. Overrides gripper joint configuration if we're using a
         deterministic reset (e.g.: hard reset from xml file)
 
         Args:
             deterministic (bool): If true, will not randomize initializations within the sim
+            rng (numpy.random._generator.Generator): Seeded random number generator
         """
         # First, run the superclass method to reset the position and controller
-        super().reset(deterministic)
+        super().reset(deterministic, rng)
 
         # Set initial q pos of the legged base
         if isinstance(self.robot_model.base, LegBaseModel):

--- a/robosuite/robots/mobile_robot.py
+++ b/robosuite/robots/mobile_robot.py
@@ -192,16 +192,17 @@ class MobileRobot(Robot):
         # First, run the superclass method to load the relevant model
         super().load_model()
 
-    def reset(self, deterministic=False):
+    def reset(self, deterministic=False, rng=None):
         """
         Sets initial pose of arm and grippers. Overrides gripper joint configuration if we're using a
         deterministic reset (e.g.: hard reset from xml file)
 
         Args:
             deterministic (bool): If true, will not randomize initializations within the sim
+            rng (numpy.random._generator.Generator): Seeded random number generator
         """
         # First, run the superclass method to reset the position and controller
-        super().reset(deterministic)
+        super().reset(deterministic, rng)
 
     def setup_references(self):
         """

--- a/robosuite/robots/robot.py
+++ b/robosuite/robots/robot.py
@@ -231,13 +231,14 @@ class Robot(object):
         """
         self.sim = sim
 
-    def reset(self, deterministic=False):
+    def reset(self, deterministic=False, rng=None):
         """
         Sets initial pose of arm and grippers. Overrides robot joint configuration if we're using a
         deterministic reset (e.g.: hard reset from xml file)
 
         Args:
             deterministic (bool): If true, will not randomize initializations within the sim
+            rng (numpy.random._generator.Generator): Seeded random number generator
 
         Raises:
             ValueError: [Invalid noise type]
@@ -246,9 +247,15 @@ class Robot(object):
         if not deterministic:
             # Determine noise
             if self.initialization_noise["type"] == "gaussian":
-                noise = np.random.randn(len(self.init_qpos)) * self.initialization_noise["magnitude"]
+                if rng is None:
+                    noise = np.random.randn(len(self.init_qpos)) * self.initialization_noise["magnitude"]
+                else:
+                    noise = rng.standard_normal(len(self.init_qpos)) * self.initialization_noise["magnitude"]
             elif self.initialization_noise["type"] == "uniform":
-                noise = np.random.uniform(-1.0, 1.0, len(self.init_qpos)) * self.initialization_noise["magnitude"]
+                if rng is None:
+                    noise = np.random.uniform(-1.0, 1.0, len(self.init_qpos)) * self.initialization_noise["magnitude"]
+                else:
+                    noise = rng.uniform(-1.0, 1.0, len(self.init_qpos)) * self.initialization_noise["magnitude"]
             else:
                 raise ValueError("Error: Invalid noise type specified. Options are 'gaussian' or 'uniform'.")
             init_qpos += noise

--- a/robosuite/robots/wheeled_robot.py
+++ b/robosuite/robots/wheeled_robot.py
@@ -73,16 +73,17 @@ class WheeledRobot(MobileRobot):
         # First, run the superclass method to load the relevant model
         super().load_model()
 
-    def reset(self, deterministic=False):
+    def reset(self, deterministic=False, rng=None):
         """
         Sets initial pose of arm and grippers. Overrides gripper joint configuration if we're using a
         deterministic reset (e.g.: hard reset from xml file)
 
         Args:
             deterministic (bool): If true, will not randomize initializations within the sim
+            rng (numpy.random._generator.Generator): Seeded random number generator
         """
         # First, run the superclass method to reset the position and controller
-        super().reset(deterministic)
+        super().reset(deterministic, rng)
 
     def setup_references(self):
         """


### PR DESCRIPTION
Before the fix, the robot's initial states will be truly random:

![Initial frames for the 1st run](https://github.com/user-attachments/assets/b309f05d-990c-493f-a322-b8d2b6106b35)
![Initial frames for the 2nd run](https://github.com/user-attachments/assets/65a179db-9f0c-467a-9fc9-bc6500709d46)

After the fix with the same seed:

![Initial frames for the 1st run](https://github.com/user-attachments/assets/e9a88d52-4d8c-4527-8cd5-febcc4315527)
![Initial frames for the 2nd run](https://github.com/user-attachments/assets/fa38e708-6611-42e9-bd4c-f723901ec147)
