### PR TITLE
feat: Dualsense device support

### DIFF
--- a/docs/algorithms/demonstrations.md
+++ b/docs/algorithms/demonstrations.md
@@ -2,11 +2,11 @@
 
 ## Collecting Human Demonstrations
 
-We provide teleoperation utilities that allow users to control the robots with input devices, such as the keyboard, [SpaceMouse](https://www.3dconnexion.com/spacemouse_compact/en/) and mujoco-gui. Such functionality allows us to collect a dataset of human demonstrations for learning. We provide an example script to illustrate how to collect demonstrations. Our [collect_human_demonstrations](https://github.com/ARISE-Initiative/robosuite/blob/master/robosuite/scripts/collect_human_demonstrations.py) script takes the following arguments:
+We provide teleoperation utilities that allow users to control the robots with input devices, such as the keyboard, [SpaceMouse](https://www.3dconnexion.com/spacemouse_compact/en/), [DualSense](https://www.playstation.com/en-us/accessories/dualsense-wireless-controller/) and mujoco-gui. Such functionality allows us to collect a dataset of human demonstrations for learning. We provide an example script to illustrate how to collect demonstrations. Our [collect_human_demonstrations](https://github.com/ARISE-Initiative/robosuite/blob/master/robosuite/scripts/collect_human_demonstrations.py) script takes the following arguments:
 
 - `directory:` path to a folder for where to store the pickle file of collected demonstrations
 - `environment:` name of the environment you would like to collect the demonstrations for
-- `device:` either "keyboard" or "spacemouse" or "mjgui"
+- `device:` either "keyboard" or "spacemouse" or "dualsense" or "mjgui"
 
 See the [devices page](https://robosuite.ai/docs/modules/devices.html) for details on how to use the devices.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -185,12 +185,21 @@ man_pages = [(master_doc, "robosuite", "robosuite Documentation", [author], 1)]
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, "robosuite", "robosuite Documentation", author, "robosuite", "ARISE", "Miscellaneous"),
+    (
+        master_doc,
+        "robosuite",
+        "robosuite Documentation",
+        author,
+        "robosuite",
+        "ARISE",
+        "Miscellaneous",
+    ),
 ]
 
 autodoc_mock_imports = [
     "robosuite.devices.mjgui",
     "robosuite.devices.spacemouse",
+    "robosuite.devices.dualsense",
     "robosuite.devices.keyboard",
     "robosuite.devices.device",
 ]

--- a/docs/demos.md
+++ b/docs/demos.md
@@ -121,6 +121,12 @@ The `demo_device_control.py` scripts shows how to teleoperate robot with [contro
         This current implementation only supports macOS (Linux support can be added).
         Download and install the [driver](https://www.3dconnexion.com/service/drivers.html) before running the script.
 
+* **DualSense**
+    We use the DualSense joystick from [DualSense](https://www.playstation.com/en-us/accessories/dualsense-wireless-controller/) to control the end-effector of the robot. The joystick provides 6-DoF control commands.
+
+    **Note:**
+        Make sure `hidapi` can detect your DualSense in your computer. In Linux, you may add udev rules in `/etc/udev/rules.d` to get access to the device without root privilege. For the rules content you can refer to [game-device-udev](https://codeberg.org/fabiscafe/game-devices-udev).
+
 * **Mujoco GUI**
         The Mujoco GUI provides a graphical user interface for viewing and interacting with a mujoco simulation. We use the GUI and a mouse to drag and drop mocap bodies, whose
         poses are tracked by a controller. More specifically, once the mujoco GUI is loaded from running `python demo_device_control.py`, you first need to hit the <Tab> key to reach the interactive mujoco viewer state. Then, you should double click on

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -37,7 +37,7 @@ The base installation requires the MuJoCo physics engine (with [mujoco](https://
    ```
    This will also install our library as an editable package, such that local changes will be reflected elsewhere without having to reinstall the package.
 
-3. (Optional) We also provide add-on functionalities, such as [OpenAI Gym](https://github.com/openai/gym) [interfaces](source/robosuite.wrappers), [inverse kinematics controllers](source/robosuite.controllers) powered by [PyBullet](http://bulletphysics.org), and [teleoperation](source/robosuite.devices) with [SpaceMouse](https://www.3dconnexion.com/products/spacemouse.html) devices. To enable these additional features, please install the extra dependencies by running
+3. (Optional) We also provide add-on functionalities, such as [OpenAI Gym](https://github.com/openai/gym) [interfaces](source/robosuite.wrappers), [inverse kinematics controllers](source/robosuite.controllers) powered by [PyBullet](http://bulletphysics.org), and [teleoperation](source/robosuite.devices) with [SpaceMouse](https://www.3dconnexion.com/products/spacemouse.html) and [DualSense](https://www.playstation.com/en-us/accessories/dualsense-wireless-controller/) devices. To enable these additional features, please install the extra dependencies by running
    ```sh
    $ pip3 install -r requirements-extra.txt
    ```

--- a/docs/modules/devices.md
+++ b/docs/modules/devices.md
@@ -1,6 +1,6 @@
 # I/O Devices
 
-Devices are used to read user input and teleoperate simulated robots in real-time. This is achieved by either using a keyboard or a [SpaceMouse](https://www.3dconnexion.com/spacemouse_compact/en/), and whose teleoperation capabilities can be demonstrated with the [demo_device_control.py](../demos.html#teleoperation) script. More generally, we support any interface that implements the [Device](../simulation/device) abstract base class. In order to support your own custom device, simply subclass this base class and implement the required methods.
+Devices are used to read user input and teleoperate simulated robots in real-time. This is achieved by either using a keyboard, a [SpaceMouse](https://www.3dconnexion.com/spacemouse_compact/en/) or a [DualSense](https://www.playstation.com/en-us/accessories/dualsense-wireless-controller/) joystick, and whose teleoperation capabilities can be demonstrated with the [demo_device_control.py](../demos.html#teleoperation) script. More generally, we support any interface that implements the [Device](../simulation/device) abstract base class. In order to support your own custom device, simply subclass this base class and implement the required methods.
 
 ## Keyboard
 
@@ -19,10 +19,10 @@ Note that the rendering window must be active for these commands to work.
 |        o-p          |                 rotate (yaw)               |
 |        y-h          |                rotate (pitch)              |
 |        e-r          |                 rotate (roll)              |
-|         b           |     toggle arm/base mode (if appli cable)  |
+|         b           |     toggle arm/base mode (if applicable)  |
 |         s           |  switch active arm (if multi-armed robot)  |
 |         =           | switch active robot (if multi-robot env)   |
-|        ESC          |                    quit                    |
+|       Ctrl+C           |                    quit                    |
 
 
 ## 3Dconnexion SpaceMouse
@@ -38,8 +38,29 @@ We support the use of a [SpaceMouse](https://www.3dconnexion.com/spacemouse_comp
 |   Move mouse laterally    |  move arm horizontally in x-y plane   |
 |   Move mouse vertically   |          move arm vertically          |
 | Twist mouse about an axis | rotate arm about a corresponding axis |
-|      ESC (keyboard)       |                 quit                  |
+|           b               |  toggle arm/base mode (if applicable) |
+|           s               |  switch active arm (if multi-armed robot)  |
+|           =               |  switch active robot (if multi-robot environment)   |
+|      Ctrl+C (keyboard)    |                 quit                  |
 
+## Sony DualSense
+
+we support the use of a [Sony DualSense](https://www.playstation.com/en-us/accessories/dualsense-wireless-controller/) as well.
+
+**Sony DualSense controls**
+
+|          Control             |                Command                |
+| :--------------------------- | :------------------------------------ |
+|       Square button          |           reset simulation            |
+|    Circle button (hold)      |             close gripper             |
+|      Move LX/LY Stick        |  move arm horizontally in x-y plane   |
+|   Press L2 Trigger with or without L1 button   |          move arm vertically          |
+|   Move RX/RY Stick           |  rotate arm about x/y axis (roll/pitch)   |
+|   Press R2 Trigger with or without R1 button   |          rotate arm about z axis (yaw)          |
+|      Triangle button         |           toggle arm/base mode (if applicable)             |
+|   Left/Right Direction Pad   |   switch active arm (if multi-armed robot)  |
+|    Up/Down Direction Pad     |    switch active robot (if multi-robot environment)  |
+|      Ctrl+C (keyboard)       |                 quit                  |
 
 ## Mujoco GUI Device
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -18,7 +18,7 @@ This framework was originally developed in late 2017 by researchers in [Stanford
 * **standardized tasks**: a set of standardized manipulation tasks of large diversity and varying complexity and RL benchmarking results for reproducible research;
 * **procedural generation**: modular APIs for programmatically creating new environments and new tasks as combinations of robot models, arenas, and parameterized 3D objects. Check out our repo [robosuite_models](https://github.com/ARISE-Initiative/robosuite_models) for extra robot models tailored to robosuite.
 * **robot controllers**: a selection of controller types to command the robots, such as joint-space velocity control, inverse kinematics control, operational space control, and whole body control;
-* **teleoperation devices**: a selection of teleoperation devices including keyboard, spacemouse and MuJoCo viewer drag-drop;
+* **teleoperation devices**: a selection of teleoperation devices including keyboard, spacemouse, dualsense and MuJoCo viewer drag-drop;
 * **multi-modal sensors**: heterogeneous types of sensory signals, including low-level physical states, RGB cameras, depth maps, and proprioception;
 * **human demonstrations**: utilities for collecting human demonstrations, replaying demonstration datasets, and leveraging demonstration data for learning. Check out our sister project [robomimic](https://arise-initiative.github.io/robomimic-web/);
 * **photorealistic rendering**: integration with advanced graphics tools that provide real-time photorealistic renderings of simulated scenes, including support for NVIDIA Isaac Sim rendering.

--- a/docs/simulation/device.rst
+++ b/docs/simulation/device.rst
@@ -1,7 +1,7 @@
 Device
 ======
 
-Devices allow for direct real-time interfacing with the MuJoCo simulation. The currently supported devices are ``Keyboard``. ``SpaceMouse`` and ``MjGUI``.
+Devices allow for direct real-time interfacing with the MuJoCo simulation. The currently supported devices are ``Keyboard``. ``SpaceMouse``. ``DualSense`` and ``MjGUI``.
 
 Base Device
 -----------
@@ -33,6 +33,18 @@ SpaceMouse Device
   .. automethod:: control
   .. automethod:: control_gripper
   .. automethod:: _display_controls
+
+DualSense Device
+-----------------
+
+.. autoclass:: robosuite.devices.dualsense.DualSense
+
+  .. automethod:: get_controller_state
+  .. automethod:: run
+  .. automethod:: control
+  .. automethod:: control_gripper
+  .. automethod:: _display_controls
+  .. automethod:: _check_connection_type
 
 MjGUI Device
 ------------

--- a/docs/source/robosuite.devices.rst
+++ b/docs/source/robosuite.devices.rst
@@ -12,6 +12,14 @@ robosuite.devices.device module
    :undoc-members:
    :show-inheritance:
 
+robosuite.devices.dualsense module
+----------------------------------
+
+.. automodule:: robosuite.devices.dualsense
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 robosuite.devices.keyboard module
 ---------------------------------
 

--- a/robosuite/demos/demo_device_control.py
+++ b/robosuite/demos/demo_device_control.py
@@ -99,16 +99,37 @@ from robosuite.controllers.composite.composite_controller import WholeBody
 from robosuite.wrappers import VisualizationWrapper
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     parser.add_argument("--environment", type=str, default="Lift")
-    parser.add_argument("--robots", nargs="+", type=str, default="Panda", help="Which robot(s) to use in the env")
     parser.add_argument(
-        "--config", type=str, default="default", help="Specified environment configuration if necessary"
+        "--robots",
+        nargs="+",
+        type=str,
+        default="Panda",
+        help="Which robot(s) to use in the env",
     )
-    parser.add_argument("--arm", type=str, default="right", help="Which arm to control (eg bimanual) 'right' or 'left'")
-    parser.add_argument("--switch-on-grasp", action="store_true", help="Switch gripper control on gripper action")
-    parser.add_argument("--toggle-camera-on-grasp", action="store_true", help="Switch camera angle on gripper action")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="default",
+        help="Specified environment configuration if necessary",
+    )
+    parser.add_argument(
+        "--arm",
+        type=str,
+        default="right",
+        help="Which arm to control (eg bimanual) 'right' or 'left'",
+    )
+    parser.add_argument(
+        "--switch-on-grasp",
+        action="store_true",
+        help="Switch gripper control on gripper action",
+    )
+    parser.add_argument(
+        "--toggle-camera-on-grasp",
+        action="store_true",
+        help="Switch camera angle on gripper action",
+    )
     parser.add_argument(
         "--controller",
         type=str,
@@ -116,8 +137,18 @@ if __name__ == "__main__":
         help="Choice of controller. Can be generic (eg. 'BASIC' or 'WHOLE_BODY_MINK_IK') or json file (see robosuite/controllers/config for examples) or None to get the robot's default controller if it exists",
     )
     parser.add_argument("--device", type=str, default="keyboard")
-    parser.add_argument("--pos-sensitivity", type=float, default=1.0, help="How much to scale position user inputs")
-    parser.add_argument("--rot-sensitivity", type=float, default=1.0, help="How much to scale rotation user inputs")
+    parser.add_argument(
+        "--pos-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale position user inputs",
+    )
+    parser.add_argument(
+        "--rot-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale rotation user inputs",
+    )
     parser.add_argument(
         "--max_fr",
         default=20,
@@ -168,12 +199,29 @@ if __name__ == "__main__":
     if args.device == "keyboard":
         from robosuite.devices import Keyboard
 
-        device = Keyboard(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = Keyboard(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
         env.viewer.add_keypress_callback(device.on_press)
     elif args.device == "spacemouse":
         from robosuite.devices import SpaceMouse
 
-        device = SpaceMouse(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = SpaceMouse(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
+    elif args.device == "dualsense":
+        from robosuite.devices import DualSense
+
+        device = DualSense(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+            reverse_xy=True,
+        )
     elif args.device == "mjgui":
         from robosuite.devices.mjgui import MJGUI
 

--- a/robosuite/demos/demo_device_control.py
+++ b/robosuite/demos/demo_device_control.py
@@ -155,6 +155,12 @@ if __name__ == "__main__":
         type=int,
         help="Sleep when simluation runs faster than specified frame rate; 20 fps is real time.",
     )
+    parser.add_argument(
+        "--reverse_xy",
+        type=bool,
+        default=False,
+        help="(DualSense Only)Reverse the effect of the x and y axes of the joystick.It is used to handle the case that the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)",
+    )
     args = parser.parse_args()
 
     # Get controller config
@@ -220,14 +226,14 @@ if __name__ == "__main__":
             env=env,
             pos_sensitivity=args.pos_sensitivity,
             rot_sensitivity=args.rot_sensitivity,
-            reverse_xy=True,
+            reverse_xy=args.reverse_xy,
         )
     elif args.device == "mjgui":
         from robosuite.devices.mjgui import MJGUI
 
         device = MJGUI(env=env)
     else:
-        raise Exception("Invalid device choice: choose either 'keyboard' or 'spacemouse'.")
+        raise Exception("Invalid device choice: choose either 'keyboard', 'dualsene' or 'spacemouse'.")
 
     while True:
         # Reset the environment

--- a/robosuite/demos/demo_sensor_corruption.py
+++ b/robosuite/demos/demo_sensor_corruption.py
@@ -25,23 +25,65 @@ from robosuite.wrappers import VisualizationWrapper
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--environment", type=str, default="Lift")
-    parser.add_argument("--robots", nargs="+", type=str, default="Panda", help="Which robot(s) to use in the env")
     parser.add_argument(
-        "--config", type=str, default="default", help="Specified environment configuration if necessary"
+        "--robots",
+        nargs="+",
+        type=str,
+        default="Panda",
+        help="Which robot(s) to use in the env",
     )
-    parser.add_argument("--arm", type=str, default="right", help="Which arm to control (eg bimanual) 'right' or 'left'")
-    parser.add_argument("--switch-on-grasp", action="store_true", help="Switch gripper control on gripper action")
     parser.add_argument(
-        "--toggle-corruption-on-grasp", action="store_true", help="Toggle corruption ON / OFF on gripper action"
+        "--config",
+        type=str,
+        default="default",
+        help="Specified environment configuration if necessary",
+    )
+    parser.add_argument(
+        "--arm",
+        type=str,
+        default="right",
+        help="Which arm to control (eg bimanual) 'right' or 'left'",
+    )
+    parser.add_argument(
+        "--switch-on-grasp",
+        action="store_true",
+        help="Switch gripper control on gripper action",
+    )
+    parser.add_argument(
+        "--toggle-corruption-on-grasp",
+        action="store_true",
+        help="Toggle corruption ON / OFF on gripper action",
     )
     parser.add_argument("--device", type=str, default="keyboard")
-    parser.add_argument("--pos-sensitivity", type=float, default=1.0, help="How much to scale position user inputs")
-    parser.add_argument("--rot-sensitivity", type=float, default=1.0, help="How much to scale rotation user inputs")
+    parser.add_argument(
+        "--pos-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale position user inputs",
+    )
+    parser.add_argument(
+        "--rot-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale rotation user inputs",
+    )
     parser.add_argument("--delay", type=float, default=0.04, help="average delay to use (sec)")
-    parser.add_argument("--corruption", type=float, default=20.0, help="Scale of corruption to use (std dev)")
+    parser.add_argument(
+        "--corruption",
+        type=float,
+        default=20.0,
+        help="Scale of corruption to use (std dev)",
+    )
     parser.add_argument("--camera", type=str, default="agentview", help="Name of camera to render")
     parser.add_argument("--width", type=int, default=512)
     parser.add_argument("--height", type=int, default=384)
+    parser.add_argument(
+        "--reverse_xy",
+        type=bool,
+        default=False,
+        help="(DualSense Only)Reverse the effect of the x and y axes of the joystick.It is used to handle the case that the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)",
+    )
+
     args = parser.parse_args()
 
     # Create argument configuration
@@ -164,13 +206,30 @@ if __name__ == "__main__":
     if args.device == "keyboard":
         from robosuite.devices import Keyboard
 
-        device = Keyboard(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = Keyboard(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
     elif args.device == "spacemouse":
         from robosuite.devices import SpaceMouse
 
-        device = SpaceMouse(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = SpaceMouse(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
+    elif args.device == "dualsense":
+        from robosuite.devices import DualSense
+
+        device = DualSense(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+            reverse_xy=args.reverse_xy,
+        )
     else:
-        raise Exception("Invalid device choice: choose either 'keyboard' or 'spacemouse'.")
+        raise Exception("Invalid device choice: choose either 'keyboard' or 'spacemouse' or 'dualsense'.")
 
     while True:
         # Reset the environment

--- a/robosuite/demos/demo_usd_export.py
+++ b/robosuite/demos/demo_usd_export.py
@@ -1,4 +1,4 @@
-""" Exports a USD file corresponding to the collected trajectory.
+"""Exports a USD file corresponding to the collected trajectory.
 
 The USD (Universal Scene Description) file format allows users to save
 trajectories such that they can be rendered in external renderers such
@@ -8,8 +8,9 @@ Start the animation in your renderer to view the full trajectory.
 
 ***IMPORTANT***: If you are using mujoco version 3.1.1, please make sure
 that you also have numpy < 2 installed in your environment. Failure to do
-so may result in incorrect renderings. 
+so may result in incorrect renderings.
 """
+
 import argparse
 
 import mujoco
@@ -26,21 +27,68 @@ if mujoco.__version__ == "3.1.1" and np.__version__[0] == "2":
     ROBOSUITE_DEFAULT_LOGGER.warning("If using mujoco==3.1.1, please use numpy < 2 for rendering with USD.")
 
 if __name__ == "__main__":
-
     parser = argparse.ArgumentParser()
     parser.add_argument("--environment", type=str, default="Lift")
-    parser.add_argument("--robots", nargs="+", type=str, default="Panda", help="Which robot(s) to use in the env")
     parser.add_argument(
-        "--config", type=str, default="default", help="Specified environment configuration if necessary"
+        "--robots",
+        nargs="+",
+        type=str,
+        default="Panda",
+        help="Which robot(s) to use in the env",
     )
-    parser.add_argument("--arm", type=str, default="right", help="Which arm to control (eg bimanual) 'right' or 'left'")
-    parser.add_argument("--camera", type=str, default="agentview", help="Which camera to use for collecting demos")
-    parser.add_argument("--switch-on-grasp", action="store_true", help="Switch gripper control on gripper action")
-    parser.add_argument("--toggle-camera-on-grasp", action="store_true", help="Switch camera angle on gripper action")
-    parser.add_argument("--controller", type=str, default="BASIC", help="Choice of controller. Can be 'ik' or 'osc'")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="default",
+        help="Specified environment configuration if necessary",
+    )
+    parser.add_argument(
+        "--arm",
+        type=str,
+        default="right",
+        help="Which arm to control (eg bimanual) 'right' or 'left'",
+    )
+    parser.add_argument(
+        "--camera",
+        type=str,
+        default="agentview",
+        help="Which camera to use for collecting demos",
+    )
+    parser.add_argument(
+        "--switch-on-grasp",
+        action="store_true",
+        help="Switch gripper control on gripper action",
+    )
+    parser.add_argument(
+        "--toggle-camera-on-grasp",
+        action="store_true",
+        help="Switch camera angle on gripper action",
+    )
+    parser.add_argument(
+        "--controller",
+        type=str,
+        default="BASIC",
+        help="Choice of controller. Can be 'ik' or 'osc'",
+    )
     parser.add_argument("--device", type=str, default="keyboard")
-    parser.add_argument("--pos-sensitivity", type=float, default=1.0, help="How much to scale position user inputs")
-    parser.add_argument("--rot-sensitivity", type=float, default=1.0, help="How much to scale rotation user inputs")
+    parser.add_argument(
+        "--pos-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale position user inputs",
+    )
+    parser.add_argument(
+        "--rot-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale rotation user inputs",
+    )
+    parser.add_argument(
+        "--reverse_xy",
+        type=bool,
+        default=False,
+        help="(DualSense Only)Reverse the effect of the x and y axes of the joystick.It is used to handle the case that the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)",
+    )
     args = parser.parse_args()
 
     # Get controller config
@@ -87,14 +135,31 @@ if __name__ == "__main__":
     if args.device == "keyboard":
         from robosuite.devices import Keyboard
 
-        device = Keyboard(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = Keyboard(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
         env.viewer.add_keypress_callback(device.on_press)
     elif args.device == "spacemouse":
         from robosuite.devices import SpaceMouse
 
-        device = SpaceMouse(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = SpaceMouse(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
+    elif args.device == "dualsense":
+        from robosuite.devices import DualSense
+
+        device = DualSense(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+            reverse_xy=args.reverse_xy,
+        )
     else:
-        raise Exception("Invalid device choice: choose either 'keyboard' or 'spacemouse'.")
+        raise Exception("Invalid device choice: choose either 'keyboard' or 'spacemouse' or 'dualsense'.")
 
     env.reset()
     cam_id = 0

--- a/robosuite/devices/__init__.py
+++ b/robosuite/devices/__init__.py
@@ -3,6 +3,7 @@ from .keyboard import Keyboard
 
 try:
     from .spacemouse import SpaceMouse
+    from .dualsense import DualSense
 except ImportError as e:
     print("Exception!", e)
     print(

--- a/robosuite/devices/__init__.py
+++ b/robosuite/devices/__init__.py
@@ -7,7 +7,7 @@ try:
 except ImportError as e:
     print("Exception!", e)
     print(
-        """Unable to load module hid, required to interface with SpaceMouse.\n
+        """Unable to load module hid, required to interface with SpaceMouse or DualSense.\n
            Only macOS is officially supported. Install the additional\n
            requirements with `pip install -r requirements-extra.txt`"""
     )

--- a/robosuite/devices/dualsense.py
+++ b/robosuite/devices/dualsense.py
@@ -182,12 +182,14 @@ class DualSense(Device):
     You can look up its vendor/product id from this method.
 
     You can test your DualSense in https://hardwaretester.com/gamepad and https://nondebug.github.io/dualsense/dualsense-explorer.html
+    DualSense HID protocol refer to https://github.com/nondebug/dualsense
 
     Args:
         env (RobotEnv): The environment which contains the robot(s) to control
                         using this device.
         pos_sensitivity (float): Magnitude of input position command scaling
         rot_sensitivity (float): Magnitude of scale input rotation commands scaling
+        reverse_xy (bool): Whether to reverse the effect of the x and y axes of the joystick. It is used to handle the case that the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)
     """
 
     def __init__(
@@ -232,7 +234,7 @@ class DualSense(Device):
         print("DualSense Connection type: %s" % ConnectionType.to_string(self.connection_type))
         print("")
         print(
-            "PS: You can set `reverse_xy` to True if the left and right sides of the view are opposite to the LX and LY of the joystick."
+            "PS: You can modify `reverse_xy` if the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)."
         )
 
         self.reverse_xy = reverse_xy
@@ -310,6 +312,17 @@ class DualSense(Device):
         self._enabled = True
 
     def _check_connection_type(self):
+        """
+        Get the connection type of the DualSense controller.
+        ConnectionType:
+        - USB: DualSense connected via USB
+        - BT01: DualSense connected via Bluetooth, sends input report id 0x01
+        - BT31: DualSense connected via Bluetooth, sends input report id 0x31
+        - UNKNOWN: Unknown connection type
+
+        Returns:
+            ConnectionType: connection type(USB, BT01, BT31, UNKNOWN)
+        """
         dummy_report = self.device.read(100)
         dummy_report_length = len(dummy_report)
         if dummy_report_length == USB_REPORT_LENGTH:

--- a/robosuite/devices/dualsense.py
+++ b/robosuite/devices/dualsense.py
@@ -7,12 +7,9 @@ In particular, we assume you are using a DualSense Wireless by default.
 
 import threading
 import time
-from collections import namedtuple
 from enum import IntFlag
-from typing import List
 
 import numpy as np
-from pynput.keyboard import Controller, Key, Listener
 
 from robosuite import make
 from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
@@ -26,7 +23,6 @@ except ModuleNotFoundError as exc:
         "requirements with `pip install -r requirements-extra.txt`"
     ) from exc
 
-from pynput.keyboard import Controller, Key, Listener
 
 import robosuite.macros as macros
 from robosuite.devices import Device
@@ -55,7 +51,6 @@ class ConnectionType(IntFlag):
 USB_REPORT_LENGTH = 64
 BT_REPORT31_LENGTH = 78
 BT_REPORT01_LENGTH = 10
-AxisSpec = namedtuple("AxisSpec", ["channel", "byte1", "byte2", "scale"])
 DUALSENSE_AXIS_LIST = ["LX", "LY", "RX", "RY", "L2_Trigger", "R2_Trigger"]
 DUALSENSE_BTN_LIST = [
     "Triangle",

--- a/robosuite/devices/dualsense.py
+++ b/robosuite/devices/dualsense.py
@@ -1,0 +1,494 @@
+"""Driver class for DualSense controller.
+
+This class provides a driver support to DualSense on macOS.
+In particular, we assume you are using a DualSense Wireless by default.
+
+"""
+
+import threading
+import time
+from collections import namedtuple
+from enum import IntFlag
+from typing import List
+
+import numpy as np
+from pynput.keyboard import Controller, Key, Listener
+
+from robosuite import make
+from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
+
+try:
+    import hid
+except ModuleNotFoundError as exc:
+    raise ImportError(
+        "Unable to load module hid, required to interface with DualSense. "
+        "Only macOS is officially supported. Install the additional "
+        "requirements with `pip install -r requirements-extra.txt`"
+    ) from exc
+
+from pynput.keyboard import Controller, Key, Listener
+
+import robosuite.macros as macros
+from robosuite.devices import Device
+from robosuite.utils.transform_utils import rotation_matrix
+
+
+class ConnectionType(IntFlag):
+    BT = 0x0
+    USB = 0x1
+    UNKNOWN = 0x2
+
+    @classmethod
+    def to_string(cls, value) -> str:
+        if value & cls.UNKNOWN:
+            return "Unknown"
+        if value & cls.BT:
+            return "Bluetooth"
+        if value & cls.USB:
+            return "USB"
+        return "Unknown"
+
+
+USB_REPORT_LENGTH = 64
+BT_REPORT_LENGTH = 78
+AxisSpec = namedtuple("AxisSpec", ["channel", "byte1", "byte2", "scale"])
+DUALSENSE_AXIS_LIST = ["LX", "LY", "RX", "RY", "L2_Trigger", "R2_Trigger"]
+DUALSENSE_BTN_LIST = [
+    "Triangle",
+    "Circle",
+    "Cross",
+    "Square",
+    "DpadUp",
+    "DpadDown",
+    "DpadLeft",
+    "DpadRight",
+    "L1",
+    "L2",
+    "L3",
+    "R1",
+    "R2",
+    "R3",
+]
+DUALSENSE_AXIS_MIN = 0
+DUALSENSE_AXIS_MAX = 255
+DUALSENSE_STICK_Neutral = 128
+DUALSENSE_Trigger_Neutral = 0
+
+
+def scale_to_control(x, axis_scale=128, min_v=-1.0, max_v=1.0):
+    """
+    Normalize raw HID readings to target range.
+
+    Args:
+        x (int): Raw reading from HID
+        axis_scale (float): (Inverted) scaling factor for mapping raw input value
+        min_v (float): Minimum limit after scaling
+        max_v (float): Maximum limit after scaling
+
+    Returns:
+        float: Clipped, scaled input from HID
+    """
+    x = x / axis_scale
+    x = min(max(x, min_v), max_v)
+    return x
+
+
+class DSState:
+    def __init__(self) -> None:
+        """
+        All dualsense states (inputs) that can be read. Second method to check if a input is pressed.
+        """
+        self.Square, self.Triangle, self.Circle, self.Cross = False, False, False, False
+        self.DpadUp, self.DpadDown, self.DpadLeft, self.DpadRight = (
+            False,
+            False,
+            False,
+            False,
+        )
+        self.L1, self.L2, self.L3, self.R1, self.R2, self.R3 = (
+            False,
+            False,
+            False,
+            False,
+            False,
+            False,
+        )
+        # neutral: 0x00, pressed: 0xff
+        self.L2_Trigger, self.R2_Trigger = 0, 0
+        self.RX, self.RY, self.LX, self.LY = 128, 128, 128, 128
+
+    def __str__(self):
+        return f"Square: {self.Square}, Triangle: {self.Triangle}, Circle: {self.Circle}, Cross: {self.Cross}, DpadUp: {self.DpadUp}, DpadDown: {self.DpadDown}, DpadLeft: {self.DpadLeft}, DpadRight: {self.DpadRight}, L1: {self.L1}, L2: {self.L2}, L3: {self.L3}, R1: {self.R1}, R2: {self.R2}, R3: {self.R3}, R2Btn: {self.R2Btn}, L2Btn: {self.L2Btn}"
+
+    def setDPadState(self, dpad_state: int) -> None:
+        """
+        Sets the dpad state variables according to the integers that was read from the controller
+
+        Args:
+            dpad_state (int): integer number representing the dpad state, actually a 4-bit number,[0,8]
+        """
+        if dpad_state == 0:
+            self.DpadUp = True
+            self.DpadDown = False
+            self.DpadLeft = False
+            self.DpadRight = False
+        elif dpad_state == 1:
+            self.DpadUp = True
+            self.DpadDown = False
+            self.DpadLeft = False
+            self.DpadRight = True
+        elif dpad_state == 2:
+            self.DpadUp = False
+            self.DpadDown = False
+            self.DpadLeft = False
+            self.DpadRight = True
+        elif dpad_state == 3:
+            self.DpadUp = False
+            self.DpadDown = True
+            self.DpadLeft = False
+            self.DpadRight = True
+        elif dpad_state == 4:
+            self.DpadUp = False
+            self.DpadDown = True
+            self.DpadLeft = False
+            self.DpadRight = False
+        elif dpad_state == 5:
+            self.DpadUp = False
+            self.DpadDown = True
+            self.DpadLeft = True
+            self.DpadRight = False
+        elif dpad_state == 6:
+            self.DpadUp = False
+            self.DpadDown = False
+            self.DpadLeft = True
+            self.DpadRight = False
+        elif dpad_state == 7:
+            self.DpadUp = True
+            self.DpadDown = False
+            self.DpadLeft = True
+            self.DpadRight = False
+        else:
+            self.DpadUp = False
+            self.DpadDown = False
+            self.DpadLeft = False
+            self.DpadRight = False
+
+
+class DualSense(Device):
+    """
+    A minimalistic driver class for DualSense with HID library.
+
+    Note: Use hid.enumerate() to view all USB human interface devices (HID).
+    Make sure DualSense is detected before running the script.
+    You can look up its vendor/product id from this method.
+
+    You can test your DualSense in https://hardwaretester.com/gamepad and https://nondebug.github.io/dualsense/dualsense-explorer.html
+
+    Args:
+        env (RobotEnv): The environment which contains the robot(s) to control
+                        using this device.
+        pos_sensitivity (float): Magnitude of input position command scaling
+        rot_sensitivity (float): Magnitude of scale input rotation commands scaling
+    """
+
+    def __init__(
+        self,
+        env,
+        vendor_id=macros.DUALSENSE_VENDOR_ID,
+        product_id=macros.DUALSENSE_PRODUCT_IDs[0],
+        pos_sensitivity=1.0,
+        rot_sensitivity=1.0,
+        reverse_xy=False,
+    ):
+        super().__init__(env)
+
+        print("Opening DualSense device")
+        self.vendor_id = vendor_id
+        self.product_id = product_id
+        self.device = hid.device()
+        try:
+            self.device.open(self.vendor_id, self.product_id)  # DualSense
+        except Exception as e:
+            ROBOSUITE_DEFAULT_LOGGER.warning(
+                "Failed to open DualSense device. "
+                "Consider killing other processes that may be using the device, "
+                f"or try other product ids for SONY DualSense in {[hex(id) for id in macros.DUALSENSE_PRODUCT_IDs]}"
+            )
+            raise e
+
+        print("Manufacturer: %s" % self.device.get_manufacturer_string())
+        print("Product: %s" % self.device.get_product_string())
+
+        self.input_report_length = -1
+        self.output_report_length = -1
+        self.connection_type = self._check_connection_type()
+        print("DualSense Connection type: %s" % ConnectionType.to_string(self.connection_type))
+        print("")
+        print(
+            "PS: You can set `reverse_xy` to True if the left and right sides of the view are opposite to the LX and LY of the joystick."
+        )
+
+        self.reverse_xy = reverse_xy
+        self.report_bytes: bytearray = None
+        self.state: DSState = DSState()
+        self.last_state: DSState = None
+
+        self.pos_sensitivity = pos_sensitivity
+        self.rot_sensitivity = rot_sensitivity
+
+        # 6-DOF variables
+        self.x, self.y, self.z = 0, 0, 0
+        self.roll, self.pitch, self.yaw = 0, 0, 0
+
+        self._display_controls()
+
+        self.single_click_and_hold = False
+
+        self._control = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        self._reset_state = 0
+        self.rotation = np.array([[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]])
+        self._enabled = False
+
+        # launch a new listener thread to listen to DualSense
+        self.thread = threading.Thread(target=self.run)
+        self.thread.daemon = True
+        self.thread.start()
+
+    @staticmethod
+    def _display_controls():
+        """
+        Method to pretty print controls.
+        """
+
+        def print_command(char, info):
+            char += " " * (35 - len(char))
+            print("{}\t{}".format(char, info))
+
+        print("")
+        print_command("Control", "Command")
+        print_command("Move LX/LY left joystick", "move arm horizontally in x-y plane")
+        print_command("Press L2 Trigger with or without L1", "move arm vertically")
+        print_command("Move RX/RY right joystick", "rotate arm about x/y axis, namely roll/pitch")
+        print_command("Press R2 Trigger with or without R1", "rotate arm about z axis, namely yaw")
+        print_command("Square button", "reset simulation")
+        print_command("Circle button (hold)", "close gripper")
+        print_command("Triangle button", "toggle arm/base mode (if applicable)")
+        print_command("Left/Right Direction Pad", "switch active arm (if multi-armed robot)")
+        print_command("Up/Down Direction Pad", "switch active robot (if multi-robot environment)")
+        print_command("Control+C", "quit")
+        print("")
+
+    def _reset_internal_state(self):
+        """
+        Resets internal state of controller, except for the reset signal.
+        """
+        super()._reset_internal_state()
+
+        self.rotation = np.array([[-1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, -1.0]])
+        # Reset 6-DOF variables
+        self.x, self.y, self.z = 0, 0, 0
+        self.roll, self.pitch, self.yaw = 0, 0, 0
+        # Reset control
+        self._control = np.zeros(6)
+        # Reset grasp
+        self.single_click_and_hold = False
+
+    def start_control(self):
+        """
+        Method that should be called externally before controller can
+        start receiving commands.
+        """
+        self._reset_internal_state()
+        self._reset_state = 0
+        self._enabled = True
+
+    def _check_connection_type(self):
+        dummy_report = self.device.read(100)
+        dummy_report_length = len(dummy_report)
+        if dummy_report_length == USB_REPORT_LENGTH:
+            self.input_report_length = USB_REPORT_LENGTH
+            self.output_report_length = USB_REPORT_LENGTH
+            return ConnectionType.USB
+        elif dummy_report_length == BT_REPORT_LENGTH:
+            self.input_report_length = BT_REPORT_LENGTH
+            self.output_report_length = BT_REPORT_LENGTH
+            return ConnectionType.BT
+        return ConnectionType.UNKNOWN
+
+    def _parse_report_bytes(self, state_bytes: bytearray):
+        new_state = DSState()
+        # states 0 is always 1
+        new_state.LX = state_bytes[1] - 128
+        new_state.LY = state_bytes[2] - 128
+        new_state.RX = state_bytes[3] - 128
+        new_state.RY = state_bytes[4] - 128
+        new_state.L2_Trigger = state_bytes[5]
+        new_state.R2_Trigger = state_bytes[6]
+
+        # state 7 always increments -> not used anywhere
+
+        buttonState = state_bytes[8]
+        new_state.Triangle = (buttonState & (1 << 7)) != 0
+        new_state.Circle = (buttonState & (1 << 6)) != 0
+        new_state.Cross = (buttonState & (1 << 5)) != 0
+        new_state.Square = (buttonState & (1 << 4)) != 0
+
+        # dpad
+        dpad_state = buttonState & 0x0F
+        new_state.setDPadState(dpad_state)
+
+        misc = state_bytes[9]
+        new_state.L1 = (misc & (1 << 0)) != 0
+        new_state.R1 = (misc & (1 << 1)) != 0
+        new_state.L2 = (misc & (1 << 2)) != 0
+        new_state.R2 = (misc & (1 << 3)) != 0
+        # new_state.share = (misc & (1 << 4)) != 0
+        # new_state.options = (misc & (1 << 5)) != 0
+        new_state.L3 = (misc & (1 << 6)) != 0
+        new_state.R3 = (misc & (1 << 7)) != 0
+        return new_state
+
+    def _check_btn_changed(self, btn_name: str):
+        """
+        Check if a button has been pressed or released.
+
+        Args:
+            btn_name (str): Name of the button to check
+
+        Returns:
+            bool: True if the button has been pressed or released, False otherwise
+        """
+        assert btn_name in DUALSENSE_BTN_LIST
+        return getattr(self.state, btn_name) != getattr(self.last_state, btn_name)
+
+    def run(self):
+        """Listener method that keeps pulling new messages."""
+        t_last_click = -1
+
+        while True:
+            d = self.device.read(self.input_report_length)
+            if d is not None and self._enabled:
+                # the reports for BT and USB are structured the same,
+                # but there is one more byte at the start of the bluetooth report.
+                # We drop that byte, so that the format matches up again.
+                report_bytes: bytearray = (
+                    bytearray(d)[1:] if self.connection_type == ConnectionType.BT else bytearray(d)
+                )
+                self.report_bytes = report_bytes
+                self.last_state = self.state
+                self.state = self._parse_report_bytes(report_bytes)
+                self.x = scale_to_control(self.state.LX if not self.reverse_xy else self.state.LY)
+                self.y = scale_to_control(self.state.LY if not self.reverse_xy else self.state.LX)
+                self.roll = scale_to_control(self.state.RX if not self.reverse_xy else self.state.RY)
+                self.pitch = scale_to_control(self.state.RY if not self.reverse_xy else self.state.RX)
+                self.z = scale_to_control(self.state.L2_Trigger)
+                if self.state.L1:
+                    self.z = -self.z
+                self.yaw = scale_to_control(self.state.R2_Trigger)
+                if self.state.R1:
+                    self.yaw = -self.yaw
+                self._control = [
+                    self.x,
+                    self.y,
+                    self.z,
+                    self.roll,
+                    self.pitch,
+                    self.yaw,
+                ]
+
+                # press left button
+                if self._check_btn_changed("Circle") and self.state.Circle:
+                    t_click = time.time()
+                    elapsed_time = t_click - t_last_click
+                    t_last_click = t_click
+                    self.single_click_and_hold = True
+
+                # release left button
+                if self._check_btn_changed("Circle") and not self.state.Circle:
+                    self.single_click_and_hold = False
+
+                # Reset
+                if self._check_btn_changed("Square") and self.state.Square:
+                    self._reset_state = 1
+                    self._enabled = False
+                    self._reset_internal_state()
+                # controls for mobile base (only applicable if mobile base present)
+                if self._check_btn_changed("Triangle") and self.state.Triangle:
+                    self.base_modes[self.active_robot] = not self.base_modes[self.active_robot]  # toggle mobile base
+
+                if self._check_btn_changed("DpadRight") and self.state.DpadRight:
+                    self.active_arm_index = (self.active_arm_index + 1) % len(self.all_robot_arms[self.active_robot])
+                elif self._check_btn_changed("DpadLeft") and self.state.DpadLeft:
+                    self.active_arm_index = (self.active_arm_index - 1) % len(self.all_robot_arms[self.active_robot])
+
+                if self._check_btn_changed("DpadUp") and self.state.DpadUp:
+                    self.active_robot = (self.active_robot + 1) % self.num_robots
+                if self._check_btn_changed("DpadDown") and self.state.DpadDown:
+                    self.active_robot = (self.active_robot - 1) % self.num_robots
+
+    @property
+    def control(self):
+        """
+        Grabs current pose of DualSense
+
+        Returns:
+            np.array: 6-DoF control value
+        """
+        return np.array(self._control)
+
+    @property
+    def control_gripper(self):
+        """
+        Maps internal states into gripper commands.
+
+        Returns:
+            float: Whether we're using single click and hold or not
+        """
+        if self.single_click_and_hold:
+            return 1.0
+        return 0
+
+    def get_controller_state(self):
+        """
+        Grabs the current state of the 3D mouse.
+
+        Returns:
+            dict: A dictionary containing dpos, orn, unmodified orn, grasp, and reset
+        """
+        dpos = self.control[:3] * 0.005 * self.pos_sensitivity
+        roll, pitch, yaw = self.control[3:] * 0.005 * self.rot_sensitivity
+
+        # convert RPY to an absolute orientation
+        drot1 = rotation_matrix(angle=-pitch, direction=[1.0, 0, 0], point=None)[:3, :3]
+        drot2 = rotation_matrix(angle=roll, direction=[0, 1.0, 0], point=None)[:3, :3]
+        drot3 = rotation_matrix(angle=yaw, direction=[0, 0, 1.0], point=None)[:3, :3]
+
+        self.rotation = self.rotation.dot(drot1.dot(drot2.dot(drot3)))
+
+        return dict(
+            dpos=dpos,
+            rotation=self.rotation,
+            raw_drotation=np.array([roll, pitch, yaw]),
+            grasp=self.control_gripper,
+            reset=self._reset_state,
+            base_mode=int(self.base_mode),
+        )
+
+    def _postprocess_device_outputs(self, dpos, drotation):
+        drotation = drotation * 50
+        dpos = dpos * 125
+
+        dpos = np.clip(dpos, -1, 1)
+        drotation = np.clip(drotation, -1, 1)
+
+        return dpos, drotation
+
+
+if __name__ == "__main__":
+    env = make("Lift", robots="Panda")
+    dualsense = DualSense(env)
+    dualsense.start_control()
+    for i in range(100):
+        # print(dualsense.control, dualsense.control_gripper)
+        print(dualsense.state)
+        time.sleep(0.5)

--- a/robosuite/macros.py
+++ b/robosuite/macros.py
@@ -38,6 +38,10 @@ MUJOCO_GPU_RENDERING = True
 SPACEMOUSE_VENDOR_ID = 9583
 SPACEMOUSE_PRODUCT_ID = 50734
 
+# DualSense settings. Used by DualSense class in robosuite/devices/dualsense.py
+DUALSENSE_VENDOR_ID = 0x054C
+DUALSENSE_PRODUCT_IDs = [0x0CE6, 0x0DF2]
+
 # If LOGGING LEVEL is set to None, the logger will be turned off
 CONSOLE_LOGGING_LEVEL = "INFO"
 # File logging is written to /tmp/robosuite_{time}_{pid}.log by default

--- a/robosuite/macros.py
+++ b/robosuite/macros.py
@@ -40,7 +40,7 @@ SPACEMOUSE_PRODUCT_ID = 50734
 
 # DualSense settings. Used by DualSense class in robosuite/devices/dualsense.py
 DUALSENSE_VENDOR_ID = 0x054C
-DUALSENSE_PRODUCT_IDs = [0x0CE6, 0x0DF2]
+DUALSENSE_PRODUCT_ID = 0x0CE6
 
 # If LOGGING LEVEL is set to None, the logger will be turned off
 CONSOLE_LOGGING_LEVEL = "INFO"

--- a/robosuite/scripts/collect_human_demonstrations.py
+++ b/robosuite/scripts/collect_human_demonstrations.py
@@ -155,7 +155,6 @@ def gather_demonstrations_as_hdf5(directory, out_dir, env_info):
     env_name = None  # will get populated at some point
 
     for ep_directory in os.listdir(directory):
-
         state_paths = os.path.join(directory, ep_directory, "state_*.npz")
         states = []
         actions = []
@@ -217,12 +216,31 @@ if __name__ == "__main__":
         default=os.path.join(suite.models.assets_root, "demonstrations_private"),
     )
     parser.add_argument("--environment", type=str, default="Lift")
-    parser.add_argument("--robots", nargs="+", type=str, default="Panda", help="Which robot(s) to use in the env")
     parser.add_argument(
-        "--config", type=str, default="default", help="Specified environment configuration if necessary"
+        "--robots",
+        nargs="+",
+        type=str,
+        default="Panda",
+        help="Which robot(s) to use in the env",
     )
-    parser.add_argument("--arm", type=str, default="right", help="Which arm to control (eg bimanual) 'right' or 'left'")
-    parser.add_argument("--camera", type=str, default="agentview", help="Which camera to use for collecting demos")
+    parser.add_argument(
+        "--config",
+        type=str,
+        default="default",
+        help="Specified environment configuration if necessary",
+    )
+    parser.add_argument(
+        "--arm",
+        type=str,
+        default="right",
+        help="Which arm to control (eg bimanual) 'right' or 'left'",
+    )
+    parser.add_argument(
+        "--camera",
+        type=str,
+        default="agentview",
+        help="Which camera to use for collecting demos",
+    )
     parser.add_argument(
         "--controller",
         type=str,
@@ -230,8 +248,18 @@ if __name__ == "__main__":
         help="Choice of controller. Can be generic (eg. 'BASIC' or 'WHOLE_BODY_MINK_IK') or json file (see robosuite/controllers/config for examples)",
     )
     parser.add_argument("--device", type=str, default="keyboard")
-    parser.add_argument("--pos-sensitivity", type=float, default=1.0, help="How much to scale position user inputs")
-    parser.add_argument("--rot-sensitivity", type=float, default=1.0, help="How much to scale rotation user inputs")
+    parser.add_argument(
+        "--pos-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale position user inputs",
+    )
+    parser.add_argument(
+        "--rot-sensitivity",
+        type=float,
+        default=1.0,
+        help="How much to scale rotation user inputs",
+    )
     parser.add_argument(
         "--renderer",
         type=str,
@@ -243,6 +271,12 @@ if __name__ == "__main__":
         default=20,
         type=int,
         help="Sleep when simluation runs faster than specified frame rate; 20 fps is real time.",
+    )
+    parser.add_argument(
+        "--reverse_xy",
+        type=bool,
+        default=False,
+        help="(DualSense Only)Reverse the effect of the x and y axes of the joystick.It is used to handle the case that the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)",
     )
     args = parser.parse_args()
 
@@ -294,11 +328,28 @@ if __name__ == "__main__":
     if args.device == "keyboard":
         from robosuite.devices import Keyboard
 
-        device = Keyboard(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = Keyboard(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
     elif args.device == "spacemouse":
         from robosuite.devices import SpaceMouse
 
-        device = SpaceMouse(env=env, pos_sensitivity=args.pos_sensitivity, rot_sensitivity=args.rot_sensitivity)
+        device = SpaceMouse(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+        )
+    elif args.device == "dualsense":
+        from robosuite.devices import DualSense
+
+        device = DualSense(
+            env=env,
+            pos_sensitivity=args.pos_sensitivity,
+            rot_sensitivity=args.rot_sensitivity,
+            reverse_xy=args.reverse_xy,
+        )
     elif args.device == "mjgui":
         assert args.renderer == "mjviewer", "Mocap is only supported with the mjviewer renderer"
         from robosuite.devices.mjgui import MJGUI


### PR DESCRIPTION
## What this does

Recently I try to integrate my DualSense controller with robosuite to teleoperate the simulated robot. I finish it and I think maybe we can merge the feature into Robosuite official codebase

|  Title               | Label           |
|----------------------|-----------------|
| Dualsense device support   | (✨ Feature)   Added [Sony PS5 DualSense](https://www.playstation.com/en-us/accessories/dualsense-wireless-controller/) device support for teleoperating simulated robot in environment  |

**PS: The doc has not been updated. If Robosuite has a plan to add this feature,  I will commit to update.**

## How it was tested
- Added `dualsense` option for `device` arg in `demos/demo_device_control.py`.
- Test with real dualsense controller in MacOS and Unbuntu20.04.

## How to checkout & try? (for the reviewer)
Connect your dualsense to your computer through USB or BlueTooth
Run
```bash
python -m robosuite.demo.demo_device_control --device dualsense
```
In MacOS, run
```bash
mjpython robosuite/demos/demo_device_control.py --device dualsense
```

![dualsense_demo](https://github.com/user-attachments/assets/5ba9ea60-cd48-484c-b656-9561cc6506bc)

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).