### PR TITLE
Hot fix `Task.generate_id_mappings()`: remove `left/right_eef_target` from id mappings

### DIFF
--- a/robosuite/models/tasks/task.py
+++ b/robosuite/models/tasks/task.py
@@ -137,7 +137,7 @@ class Task(MujocoWorldBase):
             models += [robot] + robot.models
 
         worldbody = self.mujoco_arena.root.find("worldbody")
-        exclude_bodies = ["table"]
+        exclude_bodies = ["table", "left_eef_target", "right_eef_target"]  # targets used for viz / mjgui
         top_level_bodies = [
             body.attrib.get("name")
             for body in worldbody.findall("body")


### PR DESCRIPTION
Including `left_eef_target` and `right_eef_target` in id_mappings messes up dataset collected w/o `left_eef_target` and `right_eef_target`. Also, these targets aren't part of the task --- they're included for the `mjgui` device.

## What this does
Remove `left/right_eef_target` from id mappings.

## How it was tested
Loading dataset collected using `robosuite<1.5.0`

