### PR TITLE
Allow base_type specification in manipulation envs

### DIFF
--- a/robosuite/environments/manipulation/door.py
+++ b/robosuite/environments/manipulation/door.py
@@ -33,6 +33,12 @@ class Door(ManipulationEnv):
             overrides the default gripper. Should either be single str if same gripper type is to be used for all
             robots or else it should be a list of the same length as "robots" param
 
+        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+            Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
+            None results in no base, and any other (valid) model overrides the default base. Should either be
+            single str if same base type is to be used for all robots or else it should be a list of the same
+            length as "robots" param
+
         initialization_noise (dict or list of dict): Dict containing the initialization noise parameters.
             The expected keys and corresponding value types are specified below:
 
@@ -138,6 +144,7 @@ class Door(ManipulationEnv):
         env_configuration="default",
         controller_configs=None,
         gripper_types="default",
+        base_types="default",
         initialization_noise="default",
         use_latch=True,
         use_camera_obs=True,
@@ -183,7 +190,7 @@ class Door(ManipulationEnv):
             robots=robots,
             env_configuration=env_configuration,
             controller_configs=controller_configs,
-            base_types="default",
+            base_types=base_types,
             gripper_types=gripper_types,
             initialization_noise=initialization_noise,
             use_camera_obs=use_camera_obs,

--- a/robosuite/environments/manipulation/lift.py
+++ b/robosuite/environments/manipulation/lift.py
@@ -35,6 +35,12 @@ class Lift(ManipulationEnv):
             overrides the default gripper. Should either be single str if same gripper type is to be used for all
             robots or else it should be a list of the same length as "robots" param
 
+        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+            Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
+            None results in no base, and any other (valid) model overrides the default base. Should either be
+            single str if same base type is to be used for all robots or else it should be a list of the same
+            length as "robots" param
+
         initialization_noise (dict or list of dict): Dict containing the initialization noise parameters.
             The expected keys and corresponding value types are specified below:
 
@@ -142,6 +148,7 @@ class Lift(ManipulationEnv):
         env_configuration="default",
         controller_configs=None,
         gripper_types="default",
+        base_types="default",
         initialization_noise="default",
         table_full_size=(0.8, 0.8, 0.05),
         table_friction=(1.0, 5e-3, 1e-4),

--- a/robosuite/environments/manipulation/pick_place.py
+++ b/robosuite/environments/manipulation/pick_place.py
@@ -44,6 +44,12 @@ class PickPlace(ManipulationEnv):
             overrides the default gripper. Should either be single str if same gripper type is to be used for all
             robots or else it should be a list of the same length as "robots" param
 
+        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+            Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
+            None results in no base, and any other (valid) model overrides the default base. Should either be
+            single str if same base type is to be used for all robots or else it should be a list of the same
+            length as "robots" param
+
         initialization_noise (dict or list of dict): Dict containing the initialization noise parameters.
             The expected keys and corresponding value types are specified below:
 
@@ -173,6 +179,7 @@ class PickPlace(ManipulationEnv):
         env_configuration="default",
         controller_configs=None,
         gripper_types="default",
+        base_types="default",
         initialization_noise="default",
         table_full_size=(0.39, 0.49, 0.82),
         table_friction=(1, 0.005, 0.0001),
@@ -238,7 +245,7 @@ class PickPlace(ManipulationEnv):
             robots=robots,
             env_configuration=env_configuration,
             controller_configs=controller_configs,
-            base_types="default",
+            base_types=base_types,
             gripper_types=gripper_types,
             initialization_noise=initialization_noise,
             use_camera_obs=use_camera_obs,

--- a/robosuite/environments/manipulation/stack.py
+++ b/robosuite/environments/manipulation/stack.py
@@ -35,6 +35,12 @@ class Stack(ManipulationEnv):
             overrides the default gripper. Should either be single str if same gripper type is to be used for all
             robots or else it should be a list of the same length as "robots" param
 
+        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+            Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
+            None results in no base, and any other (valid) model overrides the default base. Should either be
+            single str if same base type is to be used for all robots or else it should be a list of the same
+            length as "robots" param
+
         initialization_noise (dict or list of dict): Dict containing the initialization noise parameters.
             The expected keys and corresponding value types are specified below:
 
@@ -142,6 +148,7 @@ class Stack(ManipulationEnv):
         env_configuration="default",
         controller_configs=None,
         gripper_types="default",
+        base_types="default",
         initialization_noise="default",
         table_full_size=(0.8, 0.8, 0.05),
         table_friction=(1.0, 5e-3, 1e-4),
@@ -188,7 +195,7 @@ class Stack(ManipulationEnv):
             robots=robots,
             env_configuration=env_configuration,
             controller_configs=controller_configs,
-            base_types="default",
+            base_types=base_types,
             gripper_types=gripper_types,
             initialization_noise=initialization_noise,
             use_camera_obs=use_camera_obs,

--- a/robosuite/environments/manipulation/tool_hang.py
+++ b/robosuite/environments/manipulation/tool_hang.py
@@ -36,6 +36,12 @@ class ToolHang(ManipulationEnv):
             overrides the default gripper. Should either be single str if same gripper type is to be used for all
             robots or else it should be a list of the same length as "robots" param
 
+        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+            Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
+            None results in no base, and any other (valid) model overrides the default base. Should either be
+            single str if same base type is to be used for all robots or else it should be a list of the same
+            length as "robots" param
+
         initialization_noise (dict or list of dict): Dict containing the initialization noise parameters.
             The expected keys and corresponding value types are specified below:
 
@@ -139,6 +145,7 @@ class ToolHang(ManipulationEnv):
         env_configuration="default",
         controller_configs=None,
         gripper_types="default",
+        base_types="default",
         initialization_noise="default",
         table_full_size=(0.8, 0.8, 0.05),
         table_friction=(1.0, 5e-3, 1e-4),
@@ -181,7 +188,7 @@ class ToolHang(ManipulationEnv):
             robots=robots,
             env_configuration=env_configuration,
             controller_configs=controller_configs,
-            base_types="default",
+            base_types=base_types,
             gripper_types=gripper_types,
             initialization_noise=initialization_noise,
             use_camera_obs=use_camera_obs,

--- a/robosuite/environments/manipulation/wipe.py
+++ b/robosuite/environments/manipulation/wipe.py
@@ -65,6 +65,12 @@ class Wipe(ManipulationEnv):
             For this environment, setting a value other than the default ("WipingGripper") will raise an
             AssertionError, as this environment is not meant to be used with any other alternative gripper.
 
+        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+            Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
+            None results in no base, and any other (valid) model overrides the default base. Should either be
+            single str if same base type is to be used for all robots or else it should be a list of the same
+            length as "robots" param
+
         initialization_noise (dict or list of dict): Dict containing the initialization noise parameters.
             The expected keys and corresponding value types are specified below:
 
@@ -169,6 +175,7 @@ class Wipe(ManipulationEnv):
         env_configuration="default",
         controller_configs=None,
         gripper_types="WipingGripper",
+        base_types="default",
         initialization_noise="default",
         use_camera_obs=True,
         use_object_obs=True,


### PR DESCRIPTION
## What this does
Allow `base_type` specification in manipulation envs

