### PR TITLE
[add] add grasp qpos for inspire and fourier hand

### DIFF
--- a/robosuite/devices/device.py
+++ b/robosuite/devices/device.py
@@ -112,6 +112,7 @@ class Device(metaclass=abc.ABCMeta):
 
         # Get controller reference
         controller = robot.part_controllers[active_arm]
+        gripper = robot.gripper[active_arm]
         gripper_dof = robot.gripper[active_arm].dof
 
         assert controller.name in ["OSC_POSE", "JOINT_POSITION"], "only supporting OSC_POSE and JOINT_POSITION for now"
@@ -163,7 +164,11 @@ class Device(metaclass=abc.ABCMeta):
         )
         ac_dict[f"{active_arm}_abs"] = arm_action["abs"]
         ac_dict[f"{active_arm}_delta"] = arm_action["delta"]
-        ac_dict[f"{active_arm}_gripper"] = np.array([grasp] * gripper_dof)
+
+        if hasattr(gripper, "grasp_qpos"):
+            ac_dict[f"{active_arm}_gripper"] = getattr(gripper, "grasp_qpos")[grasp]
+        else:
+            ac_dict[f"{active_arm}_gripper"] = np.array([grasp] * gripper_dof)
 
         # clip actions between -1 and 1
         for (k, v) in ac_dict.items():

--- a/robosuite/devices/device.py
+++ b/robosuite/devices/device.py
@@ -172,7 +172,7 @@ class Device(metaclass=abc.ABCMeta):
 
         # clip actions between -1 and 1
         for (k, v) in ac_dict.items():
-            if "abs" not in k:
+            if "abs" not in k and "gripper" not in k:
                 ac_dict[k] = np.clip(v, -1, 1)
 
         return ac_dict

--- a/robosuite/models/grippers/fourier_hands.py
+++ b/robosuite/models/grippers/fourier_hands.py
@@ -32,6 +32,13 @@ class FourierLeftHand(GripperModel):
         return np.array([0.0] * 11)
 
     @property
+    def grasp_qpos(self):
+        return {
+            -1: np.array([-1.5, -1.5, -1.5, -1.5, -3, 3]),  # open
+            1: np.array([1.5, 1.5, 1.5, 1.5, 3, 3]),  # close
+        }
+
+    @property
     def speed(self):
         return 0.15
 
@@ -98,6 +105,13 @@ class FourierRightHand(GripperModel):
     @property
     def init_qpos(self):
         return np.array([0.0] * 11)
+
+    @property
+    def grasp_qpos(self):
+        return {
+            -1: np.array([-1.5, -1.5, -1.5, -1.5, -3, 3]),  # open
+            1: np.array([1.5, 1.5, 1.5, 1.5, 3, 3]),  # close
+        }
 
     @property
     def speed(self):

--- a/robosuite/models/grippers/inspire_hands.py
+++ b/robosuite/models/grippers/inspire_hands.py
@@ -32,6 +32,13 @@ class InspireLeftHand(GripperModel):
         return np.array([0.0] * 12)
 
     @property
+    def grasp_qpos(self):
+        return {
+            -1: np.array([-1.5, -1.5, -1.5, -1.5, -3, 3]),  # open
+            1: np.array([1.5, 1.5, 1.5, 1.5, 3, 3]),  # close
+        }
+
+    @property
     def speed(self):
         return 0.15
 
@@ -100,6 +107,13 @@ class InspireRightHand(GripperModel):
     @property
     def init_qpos(self):
         return np.array([0.0] * 12)
+
+    @property
+    def grasp_qpos(self):
+        return {
+            -1: np.array([-1.5, -1.5, -1.5, -1.5, -3, 3]),  # open
+            1: np.array([1.5, 1.5, 1.5, 1.5, 3, 3]),  # close
+        }
 
     @property
     def speed(self):


### PR DESCRIPTION
## What this does
- Adding grasping qpos for Inspire and Fourier hands. Used it when treating the hand as a gripper, only control its open/close pose.
- Using this qpos to set the hand action cmd in the device control class.