### PR TITLE
Update mobile_robot.py

### DIFF
--- a/robosuite/robots/mobile_robot.py
+++ b/robosuite/robots/mobile_robot.py
@@ -322,7 +322,7 @@ class MobileRobot(Robot):
         for arm in self.arms:
 
             @sensor(modality=modality)
-            def base_to_eef_pos(obs_cache):
+            def base_to_eef_pos(obs_cache, arm=arm):
                 eef_pos = np.array(self.sim.data.site_xpos[self.eef_site_id[arm]])
                 base_pos = np.array(
                     self.sim.data.site_xpos[self.sim.model.site_name2id(self.robot_model.base.correct_naming("center"))]
@@ -339,7 +339,7 @@ class MobileRobot(Robot):
                 return base_to_eef_pos
 
             @sensor(modality=modality)
-            def base_to_eef_quat(obs_cache):
+            def base_to_eef_quat(obs_cache, arm=arm):
                 """
                 Args:
                     obs_cache (dict): A dictionary containing cached observations.
@@ -376,7 +376,7 @@ class MobileRobot(Robot):
                 return T.mat2quat(base_to_eef_mat)
 
             @sensor(modality=modality)
-            def base_to_eef_quat_site(obs_cache):
+            def base_to_eef_quat_site(obs_cache, arm=arm):
                 """
                 Args:
                     obs_cache (dict): A dictionary containing cached observations.


### PR DESCRIPTION
fix: correct arm value in sensor functions

## What this does
End effector to base sensor functions was using `arm` value by reference (see the function is declared inside the loop). Essentially, if the robot had two arms in the order ["left", "right"], it still returns both values from the right arm.

|  Title               | Label           |
|----------------------|-----------------|
| Fixes        | (🐛 Bug)        |

## How to checkout & try? (for the reviewer)

```bash
python test_arm_reference.py
```

### Test Function

```python
def create_functions():
    functions = []
    arms = ['left', 'right']

    for arm in arms:
        def print_arm(arm=arm):
            print(arm)
        functions.append(print_arm)

    return functions

def create_functions_orig():
    functions = []
    arms = ['left', 'right']

    for arm in arms:
        def print_arm():
            print(arm)
        functions.append(print_arm)

    return functions

print("as an argument")
# Create the functions
funcs = create_functions()

# Call the functions
for func in funcs:
    func()

print("not as an argument")
# Create the functions
funcs = create_functions_orig()

# Call the functions
for func in funcs:
    func()

```
