### PR TITLE
Ensure EGL ImportError includes PYOPENGL_PLATFORM value

### DIFF
--- a/robosuite/renderers/context/egl_context.py
+++ b/robosuite/renderers/context/egl_context.py
@@ -26,7 +26,7 @@ elif PYOPENGL_PLATFORM.lower() != "egl":
     raise ImportError(
         "Cannot use EGL rendering platform. "
         "The PYOPENGL_PLATFORM environment variable is set to {!r} "
-        "(should be either unset or 'egl')."
+        "(should be either unset or 'egl').".format(PYOPENGL_PLATFORM)
     )
 
 from mujoco.egl import egl_ext as EGL


### PR DESCRIPTION
## What this does
This small PR fixes the missing evaluation of the `PYOPENGL_PLATFORM` environment variable in the exception:
```
ImportError: Cannot use EGL rendering platform. The PYOPENGL_PLATFORM environment variable is set to {!r} (should be either unset or 'egl').
```

## How it was tested
Run tests