### PR TITLE
data collection wrapper resets

### DIFF
--- a/robosuite/wrappers/data_collection_wrapper.py
+++ b/robosuite/wrappers/data_collection_wrapper.py
@@ -145,7 +145,7 @@ class DataCollectionWrapper(Wrapper):
         Returns:
             OrderedDict: Environment observation space after reset occurs
         """
-        self.env.unset_ep_meta() # unset any episode meta data that was previously set
+        self.env.unset_ep_meta()  # unset any episode meta data that was previously set
         ret = super().reset()
         self._start_new_episode()
         return ret

--- a/robosuite/wrappers/data_collection_wrapper.py
+++ b/robosuite/wrappers/data_collection_wrapper.py
@@ -77,6 +77,7 @@ class DataCollectionWrapper(Wrapper):
 
         # trick for ensuring that we can play MuJoCo demonstrations back
         # deterministically by using the recorded actions open loop
+        self.env.set_ep_meta(self.env.get_ep_meta())
         self.env.reset_from_xml_string(self._current_task_instance_xml)
         self.env.sim.reset()
         self.env.sim.set_state_from_flattened(self._current_task_instance_state)
@@ -144,6 +145,7 @@ class DataCollectionWrapper(Wrapper):
         Returns:
             OrderedDict: Environment observation space after reset occurs
         """
+        self.env.unset_ep_meta() # unset any episode meta data that was previously set
         ret = super().reset()
         self._start_new_episode()
         return ret


### PR DESCRIPTION
## What this does
Fix issue with resets in data collection wrapper. The `reset` function in the wrapper calls the `_start_new_episode` function, which in turn calls the `env.reset_from_xml_string` function. There is essentially two resets happening in this operation. The second reset needs to be consistent with the first one, but there is no way to ensure that currently. It only started to become an issue after I implemented randomized robot base resets. The way to ensure this is to save and set the episode meta data before calling the second reset (courtesy `env.reset_from_xml_string`). Also, we have to remember to unset the reset afterwards.


## How it was tested
I used the [collect_demos.py](https://github.com/robocasa/robocasa/blob/main/robocasa/scripts/collect_demos.py) script in RoboCasa to test this, and the issue with the robot "jumping" with the data collection wrapper at resets went away. The episode meta data currently plays no role in the base robosuite tasks, but it is important for RoboCasa tasks.


## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).