### PR TITLE
Safe Close on Spacemouse Device

### DIFF
--- a/robosuite/devices/spacemouse.py
+++ b/robosuite/devices/spacemouse.py
@@ -313,7 +313,8 @@ class SpaceMouse(Device):
                         self._reset_state = 1
                         self._enabled = False
                         self._reset_internal_state()
-            if not self._running: break
+            if not self._running:
+                break
 
     def close(self):
         self._running = False


### PR DESCRIPTION
## What this does
In devices/spacemouse.py:

**1. Added safer shutdown function.**

**(🐛 Bug)** When running test_fixtures.py in robocasa, after pressing Ctrl+C to bring up the next window, there are different errors on different operating systems: (1) The robotic arm cannot be moved on Windows. (2) On Ubuntu system it shows read device error. The reason for this is that the occupancy problem occurs when the device is reinitialized after the device is not fully released, so a safe shutdown function has been added.

**2. Added is_empty_action judgment.**

**(✨ Feature)** We don't really want to start controlling the device as soon as we enter the robocasa environment, which can be a bit unstable, so we add the is_empty_action judgment.

## How it was tested
test at "test_fixtures.py" script on robocasa(lightwheel branch).

## How to checkout & try? (for the reviewer)
run "test_fixture.py" on robocasa. Try Ctrl+C to observe the next control.
You can add

```python
device.close()
device=None
```

below line 317 on robocasa(lightwheel branch), then the next control will be back to normal.