### PR TITLE
add `CGLGLContext` for off-screen rendering on Darwin

### DIFF
--- a/robosuite/renderers/context/cgl_context.py
+++ b/robosuite/renderers/context/cgl_context.py
@@ -1,0 +1,9 @@
+"""An OpenGL context created via CGL."""
+
+from mujoco.cgl import GLContext
+
+class CGLGLContext(GLContext):
+    """An OpenGL context created via CGL."""
+
+    def __init__(self, max_width, max_height, device_id=0):
+        super().__init__(max_width, max_height)

--- a/robosuite/utils/binding_utils.py
+++ b/robosuite/utils/binding_utils.py
@@ -69,6 +69,8 @@ class MjRenderContext:
                 from robosuite.renderers.context.osmesa_context import OSMesaGLContext as GLContext
             elif _SYSTEM == "Linux" and _MUJOCO_GL == "egl":
                 from robosuite.renderers.context.egl_context import EGLGLContext as GLContext
+            elif _SYSTEM == "Darwin" and _MUJOCO_GL == "cgl":
+                from robosuite.renderers.context.cgl_context import CGLGLContext as GLContext
             else:
                 from robosuite.renderers.context.glfw_context import GLFWGLContext as GLContext
 


### PR DESCRIPTION
## What this does

Fix: add `CGLGLContext` for off-screen rendering properly on Darwin.
