### PR TITLE
update part controller config to include joint indices

### DIFF
--- a/robosuite/robots/robot.py
+++ b/robosuite/robots/robot.py
@@ -912,7 +912,7 @@ class Robot(object):
                 self.part_controller_config[gripper_name]["ndim"] = self.gripper[arm].dof
                 self.part_controller_config[gripper_name]["policy_freq"] = self.control_freq
                 self.part_controller_config[gripper_name]["joint_indexes"] = {
-                    "joints": self.gripper_joints[arm],
+                    "joints": self._ref_joints_indexes_dict[gripper_name],
                     "actuators": self._ref_joint_gripper_actuator_indexes[arm],
                     "qpos": self._ref_gripper_joint_pos_indexes[arm],
                     "qvel": self._ref_gripper_joint_vel_indexes[arm],


### PR DESCRIPTION
## What this does
Fixes #673 




## How it was tested
To test change the basic controller to use JOINT_POSITION for grippers. (change the this [line](https://github.com/ARISE-Initiative/robosuite/blob/master/robosuite/controllers/config/default/composite/basic.json#L46) to `"type": "JOINT_POSITION"`). Then run `python robosuite/scripts/collect_human_demonstrations.py --environment Lift`

Before the changes in this branch, the script will have an exception. After the changes controlling the gripper with JOINT_POSITION control should work fine.
