### PR TITLE
Fix: Prevent GPU memory leak by ensuring sim destruction on reset

### DIFF
--- a/robosuite/environments/base.py
+++ b/robosuite/environments/base.py
@@ -274,7 +274,8 @@ class MujocoEnv(metaclass=EnvMeta):
         if self.hard_reset and not self.deterministic_reset:
             if self.renderer == "mujoco":
                 self._destroy_viewer()
-                self._destroy_sim()
+
+            self._destroy_sim()
             self._load_model()
             self._initialize_sim()
         # Else, we only reset the sim internally


### PR DESCRIPTION
Hello, thank you for maintaining the awesome robosuite!

## What this does

I've experienced a GPU memory leak while running a long session with many resets. I found that `self._destroy_sim()` was not being called during reset because my renderer was `mjviewer`.

With `self._destroy_sim()` properly called in each reset regardless of the renderer, I no longer see the GPU memory leak.

## How it was tested
I monitored `nvidia-smi` during my script before and after the fix.

Thanks!