### PR TITLE
fix baxter mesh issues

### DIFF
--- a/robosuite/models/assets/robots/baxter/robot.xml
+++ b/robosuite/models/assets/robots/baxter/robot.xml
@@ -9,7 +9,7 @@
     <material name="Material.003" specular="0.5" shininess="0.225" rgba="0.640000 0.000000 0.000000 1.000000"/>
     <material name="Material_001.003" specular="0.5" shininess="0.225" rgba="0.000000 0.000000 0.000000 1.000000"/>
     <mesh name="H1_0" file="obj_meshes/head/H1/H1_0.obj"/>
-    <mesh name="H1_1" file="obj_meshes/head/H1/H1_1.obj"/>
+    <mesh name="H1_1" file="obj_meshes/head/H1/H1_1.obj" inertia="shell"/>
     <!-- lower elbow E1 material and mesh -->
     <material name="Material_001.004" specular="0.5" shininess="0.225" rgba="0.512000 0.000000 0.000000 1.000000"/>
     <material name="Material_002" specular="0.5" shininess="0.225" rgba="0.016303 0.016303 0.016303 1.000000"/>

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "numpy>=1.13.3",
         "numba>=0.49.1",
         "scipy>=1.2.3",
-        "mujoco>=3.2.3",
+        "mujoco>=3.3.0",
         "mink>=0.0.5",
         "Pillow",
         "opencv-python",

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "scipy>=1.2.3",
         "mujoco>=3.3.0",
         "mink>=0.0.5",
+        "qpsolvers[quadprog]>=4.3.1",
         "Pillow",
         "opencv-python",
         "pynput",


### PR DESCRIPTION
## What this does

Fixes #681 

With these fixes there should not be any issue with initializing Baxter with Mujoco >= 3.3.0. However, initializing Baxter with an earlier version will cause issues.

Refer to mujoco [changelog](https://mujoco.readthedocs.io/en/3.3.0/changelog.html) for version 3.3.0, item 10 for justification on why the fix works.

Also adds `qpsolvers[quadprog]>=4.3.1` to setup.py to make tests using Mink to pass


## How it was tested
run `python robosuite/scripts/collect_human_demonstrations.py` with Baxter and Mujoco >= 3.3.0. With these changes it should work fine. Without it will not work.