### PR TITLE
Updating base type comments

### DIFF
--- a/robosuite/environments/manipulation/manipulation_env.py
+++ b/robosuite/environments/manipulation/manipulation_env.py
@@ -25,9 +25,9 @@ class ManipulationEnv(RobotEnv):
             dict if same controller is to be used for all robots or else it should be a list of the same length as
             "robots" param
 
-        base_types (None or str or list of str): type of base, used to instantiate base models from base factory.
+        base_types (str or list of str): type of base, used to instantiate base models from base factory.
             Default is "default", which is the default base associated with the robot(s) the 'robots' specification.
-            None results in no base, and any other (valid) model overrides the default base. Should either be
+            "NullMount" results in no base, and any other (valid) model overrides the default base. Should either be
             single str if same base type is to be used for all robots or else it should be a list of the same
             length as "robots" param
 

--- a/robosuite/environments/robot_env.py
+++ b/robosuite/environments/robot_env.py
@@ -25,9 +25,9 @@ class RobotEnv(MujocoEnv):
             dict if same controller is to be used for all robots or else it should be a list of the same length as
             "robots" param
 
-        mount_types (None or str or list of str): type of mount, used to instantiate mount models from mount factory.
+        mount_types (str or list of str): type of mount, used to instantiate mount models from mount factory.
             Default is "default", which is the default mount associated with the robot(s) the 'robots' specification.
-            None results in no mount, and any other (valid) model overrides the default mount. Should either be
+            "NullMount" results in no mount, and any other (valid) model overrides the default mount. Should either be
             single str if same mount type is to be used for all robots or else it should be a list of the same
             length as "robots" param
 


### PR DESCRIPTION
Updated the comments in manipulation_env.py and robot_env.py.

Initially in the class description for the base/mount type, it was mentioned to use None. 

Changed this None to "NullMount" since the old comment was not accurate. 