### PR TITLE
fix: new mink lib has a breaking change on import execptions

### DIFF
--- a/robosuite/examples/third_party_controller/mink_controller.py
+++ b/robosuite/examples/third_party_controller/mink_controller.py
@@ -9,7 +9,7 @@ import mujoco
 import mujoco.viewer
 import numpy as np
 from mink.configuration import Configuration
-from mink.tasks.exceptions import TargetNotSet
+from mink.exceptions import TargetNotSet
 from mink.tasks.frame_task import FrameTask
 
 import robosuite.utils.transform_utils as T

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
         "numba>=0.49.1",
         "scipy>=1.2.3",
         "mujoco>=3.3.0",
-        "mink>=0.0.5",
+        "mink>=0.0.11",
         "qpsolvers[quadprog]>=4.3.1",
         "Pillow",
         "opencv-python",


### PR DESCRIPTION
## What this does
fix: new mink lib has a breaking change on import execptions
|  Title               | Label           |
|----------------------|-----------------|
| Fixes #[issue]       | (🐛 Bug)        |



## How it was tested
```
from mink.exceptions import TargetNotSet
```