### PR TITLE
Fixes mobile base xmls and controller logic

### DIFF
--- a/robosuite/controllers/parts/mobile_base/joint_vel.py
+++ b/robosuite/controllers/parts/mobile_base/joint_vel.py
@@ -206,17 +206,16 @@ class MobileBaseJointVelocityController(MobileBaseController):
         curr_theta = T.mat2euler(curr_ori)[2]  # np.arctan2(curr_pos[1], curr_pos[0])
         theta = curr_theta - init_theta
 
-        base_action = np.copy([action[i] for i in [1, 0, 2]])
         # input raw base action is delta relative to current pose of base
         # controller expects deltas relative to initial pose of base at start of episode
         # transform deltas from current base pose coordinates to initial base pose coordinates
-        x, y = base_action[0:2]
+        x, y = action[0:2]
 
         # do the reverse of theta rotation
-        base_action[0] = x * np.cos(theta) + y * np.sin(theta)
-        base_action[1] = -x * np.sin(theta) + y * np.cos(theta)
+        action[0] = x * np.cos(theta) + y * np.sin(theta)
+        action[1] = -x * np.sin(theta) + y * np.cos(theta)
 
-        self.goal_qvel = base_action
+        self.goal_qvel = action
         if self.interpolator is not None:
             self.interpolator.set_goal(self.goal_qvel)
 

--- a/robosuite/models/assets/bases/floating_legged_base.xml
+++ b/robosuite/models/assets/bases/floating_legged_base.xml
@@ -12,8 +12,8 @@
 
             <site name="center" type="sphere" pos="0 0 0" size="0.01" group="1" rgba="0 0 0 0"/>
 
-            <joint name="joint_mobile_forward" pos="0 0 0" axis="0 1 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
-			<joint name="joint_mobile_side" pos="0 0 0" axis="1 0 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
+            <joint name="joint_mobile_forward" pos="0 0 0" axis="1 0 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
+			<joint name="joint_mobile_side" pos="0 0 0" axis="0 1 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
 			<joint name="joint_mobile_yaw" pos="-0.21 0 0" axis="0 0 1" type="hinge" limited="false" damping="0" armature="0.0" frictionloss="250"/>
         </body>
     </worldbody>

--- a/robosuite/models/assets/bases/null_mobile_base.xml
+++ b/robosuite/models/assets/bases/null_mobile_base.xml
@@ -11,8 +11,8 @@
 
             <site name="center" type="sphere" pos="0 0 0" size="0.01" group="1" rgba="0 0 0 0"/>
 
-            <joint name="joint_mobile_forward" pos="0 0 0" axis="0 1 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
-			<joint name="joint_mobile_side" pos="0 0 0" axis="1 0 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
+            <joint name="joint_mobile_forward" pos="0 0 0" axis="1 0 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
+			<joint name="joint_mobile_side" pos="0 0 0" axis="0 1 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
 			<joint name="joint_mobile_yaw" pos="-0.21 0 0" axis="0 0 1" type="hinge" limited="false" damping="0" armature="0.0" frictionloss="250"/>
         </body>
     </worldbody>

--- a/robosuite/models/assets/bases/omron_mobile_base.xml
+++ b/robosuite/models/assets/bases/omron_mobile_base.xml
@@ -53,8 +53,8 @@
                 <geom pos="0 0 0" size="0.35 0.25 0.19" type="box" name="pedestal_feet_col" density="10"/>
             </body>
 
-            <joint name="joint_mobile_forward" pos="-0.21 0 0" axis="0 1 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
-			<joint name="joint_mobile_side" pos="-0.21 0 0" axis="1 0 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
+            <joint name="joint_mobile_forward" pos="-0.21 0 0" axis="1 0 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
+			<joint name="joint_mobile_side" pos="-0.21 0 0" axis="0 1 0" type="slide" limited="false" damping="0" armature="0.0" frictionloss="250"/>
 			<joint name="joint_mobile_yaw" pos="-0.21 0 0" axis="0 0 1" type="hinge" limited="false" damping="0" armature="0.0" frictionloss="250"/>
         </body>
     </worldbody>


### PR DESCRIPTION
Currently, for mobile base xmls, "forward" means "side" while "side" means forward. Consequently `mobile_base/joint_vel.py` has a mysterious action switching logic.

## What this does
Fix mobile base xml so forward means forward (x axis), side means sid…e (y-axis); fix controller's weird x-y axis switching logic.

## How it was tested
`python robosuite/scripts/collect_human_demonstrations.py --robots PandaOmron` still works as expected.