### PR TITLE
fix site scaling to get all sites from world body

### DIFF
--- a/robosuite/models/arenas/arena.py
+++ b/robosuite/models/arenas/arena.py
@@ -155,6 +155,7 @@ class Arena(MujocoXML):
         scale_mjcf_model(
             obj=obj,
             asset_root=self.asset,
+            worldbody=self.worldbody,
             scale=scale,
             get_elements_func=get_elements,
             scale_slide_joints=False,  # Arena doesn't handle slide joints

--- a/robosuite/models/objects/objects.py
+++ b/robosuite/models/objects/objects.py
@@ -97,28 +97,6 @@ class MujocoObject(MujocoModel):
         assert self._obj is not None, "Object XML tree has not been generated yet!"
         return self._obj
 
-    def set_scale(self, scale, obj=None):
-        """
-        Scales each geom, mesh, site, body, and joint ranges (for slide joints).
-        Called during initialization but can also be used externally.
-        Args:
-            scale (float or list of floats): Scale factor (1 or 3 dims)
-            obj (ET.Element): Root object to apply scaling to. Defaults to root object of model.
-        """
-        if obj is None:
-            obj = self._obj
-
-        self._scale = scale
-
-        # Use the centralized scaling utility function
-        scale_mjcf_model(
-            obj=obj,
-            asset_root=self.asset,
-            scale=scale,
-            get_elements_func=get_elements,
-            scale_slide_joints=True,
-        )
-
     def exclude_from_prefixing(self, inp):
         """
         A function that should take in either an ET.Element or its attribute (str) and return either True or False,
@@ -506,6 +484,7 @@ class MujocoXMLObject(MujocoObject, MujocoXML):
         scale_mjcf_model(
             obj=obj,
             asset_root=self.asset,
+            worldbody=self.worldbody,
             scale=scale,
             get_elements_func=get_elements,
             scale_slide_joints=False,  # MujocoXMLObject doesn't handle slide joints

--- a/robosuite/utils/mjcf_utils.py
+++ b/robosuite/utils/mjcf_utils.py
@@ -1060,7 +1060,7 @@ def scale_site_element(element, scale_array):
         element.set("size", s_size)
 
 
-def scale_mjcf_model(obj, asset_root, scale, get_elements_func, scale_slide_joints=True):
+def scale_mjcf_model(obj, asset_root, worldbody, scale, get_elements_func, scale_slide_joints=True):
     """
     Scales all elements (geoms, meshes, bodies, joints, sites) in an MJCF model.
 
@@ -1098,7 +1098,7 @@ def scale_mjcf_model(obj, asset_root, scale, get_elements_func, scale_slide_join
         scale_joint_element(elem, scale_array, scale_slide_joints)
 
     # Scale sites
-    site_pairs = get_elements_func(obj, "site")
+    site_pairs = get_elements_func(worldbody, "site")
     for (_, elem) in site_pairs:
         scale_site_element(elem, scale_array)
 


### PR DESCRIPTION
## What this does
fixes https://github.com/robocasa/robocasa/issues/154.

The latest commit that refactors `set_scale` sets the scale for sites under the `self._obj` however, it should be looking for sites under `self.worldbody` (as done prior to the latest commit in master commit)


## How it was tested
`python -m robocasa.demos.demo_kitchen_scenes` using public main of robocasa

## How to checkout & try? (for the reviewer)
run above command with this branch and with master. With this branch it should work, on master will get error 

`ValueError: Overhang value is too large, must be lower than front padding (-0.22)`
