### PR TITLE
Absolute action + two arm env fix

### DIFF
--- a/robosuite/controllers/composite/composite_controller.py
+++ b/robosuite/controllers/composite/composite_controller.py
@@ -245,6 +245,7 @@ class WholeBody(CompositeController):
         # task space actions (such as end effector poses) to joint actions (such as joint angles or joint torques)
 
         self._whole_body_controller_action_split_indexes: OrderedDict = OrderedDict()
+        self.input_action_goal = None
 
     def _init_controllers(self):
         for part_name in self.part_controller_config.keys():
@@ -323,6 +324,7 @@ class WholeBody(CompositeController):
             previous_idx = last_idx
 
     def set_goal(self, all_action):
+        self.input_action_goal = all_action.copy()
         target_qpos = self.joint_action_policy.solve(all_action[: self.joint_action_policy.control_dim])
         # create new all_action vector with the IK solver's actions first
         all_action = np.concatenate([target_qpos, all_action[self.joint_action_policy.control_dim :]])
@@ -433,6 +435,7 @@ class WholeBodyIK(WholeBody):
 
         # Loop through ref_names and validate against mujoco model
         original_ref_names = self.composite_controller_specific_config.get("ref_name", [])
+        original_ref_names = [name.format(idn=self.robot_model.idn) for name in original_ref_names]
         for ref_name in original_ref_names:
             if ref_name in self.sim.model.site_names:  # Check if the site exists in the mujoco model
                 valid_ref_names.append(ref_name)

--- a/robosuite/controllers/config/default/composite/whole_body_ik.json
+++ b/robosuite/controllers/config/default/composite/whole_body_ik.json
@@ -1,7 +1,7 @@
 {
     "type": "WHOLE_BODY_IK",
     "composite_controller_specific_configs": {
-        "ref_name": ["gripper0_right_grip_site", "gripper0_left_grip_site"],
+        "ref_name": ["gripper{idn}_right_grip_site", "gripper{idn}_left_grip_site"],
         "interpolation": null,
         "actuation_part_names": ["torso", "head", "right", "left", "base", "legs"],
         "max_dq": 4,

--- a/robosuite/scripts/collect_human_demonstrations.py
+++ b/robosuite/scripts/collect_human_demonstrations.py
@@ -5,6 +5,7 @@ The demonstrations can be played back using the `playback_demonstrations_from_hd
 """
 
 import argparse
+import copy
 import datetime
 import json
 import os
@@ -15,9 +16,93 @@ import h5py
 import numpy as np
 
 import robosuite as suite
+import robosuite.utils.transform_utils as T
 from robosuite.controllers import load_composite_controller_config
 from robosuite.controllers.composite.composite_controller import WholeBody
+from robosuite.controllers.parts.arm import InverseKinematicsController, OperationalSpaceController
+from robosuite.utils.log_utils import ROBOSUITE_DEFAULT_LOGGER
 from robosuite.wrappers import DataCollectionWrapper, VisualizationWrapper
+
+
+def get_arm_ref(env, robot, arm):
+    """
+    Extracts the reference pose of the specified arm of the robot.
+    """
+    if robot.composite_controller_config["type"] in ["WHOLE_BODY_MINK_IK", "HYBRID_WHOLE_BODY_MINK_IK"]:
+        ref_frame = robot.composite_controller.composite_controller_specific_config.get("ik_input_ref_frame", "world")
+
+        # general case
+        id = robot.robot_model.idn
+        site_name = f"gripper{id}_{arm}_grip_site"
+        # update next target based on current achieved pose
+        pos = env.sim.data.get_site_xpos(site_name).copy()
+        ori = env.sim.data.get_site_xmat(site_name).copy()
+        # convert target in world coordinate to
+        pose_in_world = np.eye(4)
+        pose_in_world[:3, 3] = pos
+        pose_in_world[:3, :3] = ori
+        pose_in_base = robot.composite_controller.joint_action_policy.transform_pose(
+            src_frame_pose=pose_in_world,
+            src_frame="world",  # mocap pose is world coordinates
+            dst_frame=ref_frame,
+        )
+        pos, ori = pose_in_base[:3, 3], pose_in_base[:3, :3]
+        axisangle = T.quat2axisangle(T.mat2quat(ori))
+
+        abs_action = np.concatenate([pos, axisangle])
+
+        return abs_action
+    elif robot.composite_controller_config["type"] in ["WHOLE_BODY_IK"]:
+        id = robot.robot_model.idn
+        site_name = f"gripper{id}_{arm}_grip_site"
+        # update next target based on current achieved pose
+        pos = env.sim.data.get_site_xpos(site_name).copy()
+        ori = env.sim.data.get_site_xmat(site_name).copy()
+
+        axisangle = T.quat2axisangle(T.mat2quat(ori))
+
+        abs_action = np.concatenate([pos, axisangle])
+
+        return abs_action
+    else:
+        raise NotImplementedError
+
+
+def get_abs_arm_static_target(robot, arm, env):
+    """
+    Extracts the internal goal absolute target for the specified arm of the robot. If the
+    internal goal is not set, it extracts the current achieved pose of the arm.
+    This is needed to maintain the arm position of a robot when the device is not controlling it.
+
+
+    Args:
+        robot (Robot): the robot to extract the arm target from
+        arm (str): the arm to extract the target for
+
+    Returns:
+        np.ndarray: the absolute target for the arm
+    """
+    abs_action = np.zeros(6)
+    if isinstance(robot.composite_controller, WholeBody):
+        controller_input_type = robot.composite_controller.joint_action_policy.input_type
+        prev_action = robot.composite_controller.input_action_goal
+        if prev_action is None:
+            abs_action = get_arm_ref(env, robot, arm)
+        else:
+            start_idx, end_idx = robot.composite_controller._whole_body_controller_action_split_indexes[arm]
+            abs_action = prev_action[start_idx:end_idx]
+    elif isinstance(robot.part_controllers[arm], OperationalSpaceController):
+        controller_input_type = robot.part_controllers[arm].input_type
+        abs_action = robot.part_controllers[arm].delta_to_abs_action(np.zeros(6), "achieved")
+    else:
+        ROBOSUITE_DEFAULT_LOGGER.warning(
+            "Unable to extract absolute target for arm {} of robot {} returning zeros. This is only a problem is it is a TwoArmEnv".format(
+                arm, robot.robot_model.idn
+            )
+        )
+
+    assert controller_input_type == "absolute", f"Only calculating absolute targets"
+    return abs_action
 
 
 def collect_human_trajectory(env, device, arm, max_fr):
@@ -82,9 +167,32 @@ def collect_human_trajectory(env, device, arm, max_fr):
                 action_dict[arm] = input_ac_dict[f"{arm}_abs"]
             else:
                 raise ValueError
+        all_robot_action_dicts = []
+        # set inactive robot action dicts
+        for i, robot in enumerate(env.robots):
+            if i == device.active_robot:
+                all_robot_action_dicts.append(action_dict)
+                continue
+
+            inactive_robot_ac_dict = copy.deepcopy(all_prev_gripper_actions[i])
+            if isinstance(robot.composite_controller, WholeBody):
+                controller_input_type = robot.composite_controller.joint_action_policy.input_type
+            else:
+                controller_input_type = robot.part_controllers[arm].input_type
+
+            # update action when controller input type is absolute so that the inactive robot does not move
+            if controller_input_type == "absolute":
+                for arm in robot.arms:
+                    # set goal mode to acheived to avoid changing the target
+                    inactive_robot_ac_dict[arm] = get_abs_arm_static_target(robot, arm, env)
+                    print(
+                        f"Inactive robot {robot.robot_model.idn} arm {arm} action: {inactive_robot_ac_dict[arm]}"
+                    )  # DEBUG
+
+            all_robot_action_dicts.append(inactive_robot_ac_dict)
 
         # Maintain gripper state for each robot but only update the active robot with action
-        env_action = [robot.create_action_vector(all_prev_gripper_actions[i]) for i, robot in enumerate(env.robots)]
+        env_action = [robot.create_action_vector(all_robot_action_dicts[i]) for i, robot in enumerate(env.robots)]
         env_action[device.active_robot] = active_robot.create_action_vector(action_dict)
         env_action = np.concatenate(env_action)
         for gripper_ac in all_prev_gripper_actions[device.active_robot]:
@@ -301,6 +409,14 @@ if __name__ == "__main__":
     # Check if we're using a multi-armed environment and use env_configuration argument if so
     if "TwoArm" in args.environment:
         config["env_configuration"] = args.config
+        # make fresh copies of the controller config for each robot since they will have different references
+        config["controller_configs"] = [
+            load_composite_controller_config(
+                controller=args.controller,
+                robot=robot,
+            )
+            for robot in args.robots
+        ]
 
     # Create environment
     env = suite.make(

--- a/robosuite/scripts/collect_human_demonstrations.py
+++ b/robosuite/scripts/collect_human_demonstrations.py
@@ -185,9 +185,6 @@ def collect_human_trajectory(env, device, arm, max_fr):
                 for arm in robot.arms:
                     # set goal mode to acheived to avoid changing the target
                     inactive_robot_ac_dict[arm] = get_abs_arm_static_target(robot, arm, env)
-                    print(
-                        f"Inactive robot {robot.robot_model.idn} arm {arm} action: {inactive_robot_ac_dict[arm]}"
-                    )  # DEBUG
 
             all_robot_action_dicts.append(inactive_robot_ac_dict)
 


### PR DESCRIPTION
## What this does
Fixes #737 

It specifically fixes two issues when initializing two robots.

1. Reference poses in WHOLE_BODY_IK were incorrect for the second robot in any TwoArmEnv
2. With absolute action control, the pose of the robot not being controlled is not maintained 


## How it was tested
Run any environment with two robots with absolute action control before and after these changes were made for example

` python robosuite/scripts/collect_human_demonstrations.py --environment TwoArmLift --device spacemouse --robots Panda Panda --config parallel --controller WHOLE_BODY_IK`

Before the changes the second robot will never stay in the same pose when not being controller After these changes they do