### PR TITLE
Add input_ref_frame = base option for whole body ik and devices

### DIFF
--- a/robosuite/controllers/composite/composite_controller.py
+++ b/robosuite/controllers/composite/composite_controller.py
@@ -474,5 +474,6 @@ class WholeBodyIK(WholeBody):
             max_dq_torso=self.composite_controller_specific_config.get("ik_max_dq_torso", 0.2),
             input_rotation_repr=self.composite_controller_specific_config.get("ik_input_rotation_repr", "axis_angle"),
             input_type=self.composite_controller_specific_config.get("ik_input_type", "axis_angle"),
+            input_ref_frame=self.composite_controller_specific_config.get("ik_input_ref_frame", "world"),
             debug=self.composite_controller_specific_config.get("verbose", False),
         )

--- a/robosuite/controllers/config/robots/default_pandaomron_whole_body_ik.json
+++ b/robosuite/controllers/config/robots/default_pandaomron_whole_body_ik.json
@@ -1,0 +1,116 @@
+{
+    "type": "WHOLE_BODY_IK",
+    "composite_controller_specific_configs": {
+        "ref_name": ["gripper0_right_grip_site", "gripper0_left_grip_site"],
+        "interpolation": null,
+        "actuation_part_names": ["right", "left"],
+        "max_dq": 4,
+        "nullspace_joint_weights": {
+            "robot0_torso_waist_yaw": 100.0,
+            "robot0_torso_waist_pitch": 100.0,
+            "robot0_torso_waist_roll": 500.0,
+            "robot0_l_shoulder_pitch": 4.0,
+            "robot0_r_shoulder_pitch": 4.0,
+            "robot0_l_shoulder_roll": 3.0,
+            "robot0_r_shoulder_roll": 3.0,
+            "robot0_l_shoulder_yaw": 2.0,
+            "robot0_r_shoulder_yaw": 2.0
+        },
+        "ik_pseudo_inverse_damping": 5e-2,
+        "ik_integration_dt": 1e-1,
+        "ik_max_dq": 4.0,
+        "ik_max_dq_torso": 0.2,
+        "ik_input_type": "absolute",
+        "ik_input_ref_frame": "base",
+        "ik_input_rotation_repr": "axis_angle",
+        "verbose": false
+    },
+    "body_parts": {
+        "arms": {
+            "right": {
+                "type" : "JOINT_POSITION",
+                "input_max": 1,
+                "input_min": -1,
+                "input_type": "absolute",
+                "output_max": 0.5,
+                "output_min": -0.5,
+                "kd": 200,
+                "kv": 200,
+                "kp": 1000,
+                "velocity_limits": [-1,1],
+                "kp_limits": [0, 1000],
+                "interpolation": null,
+                "ramp_ratio": 0.2,
+                "gripper": {
+                    "type": "GRIP"
+                }
+            },
+            "left": {
+                "type" : "JOINT_POSITION",
+                "input_max": 1,
+                "input_min": -1,
+                "input_type": "absolute",
+                "output_max": 0.5,
+                "output_min": -0.5,
+                "kd": 200,
+                "kv": 200,
+                "kp": 1000,
+                "velocity_limits": [-1,1],
+                "kp_limits": [0, 1000],
+                "interpolation": null,
+                "ramp_ratio": 0.2,
+                "gripper": {
+                    "type": "GRIP"
+                }
+            }
+        },
+        "torso": {
+            "type" : "JOINT_POSITION",
+            "input_max": 1,
+            "input_min": -1,
+            "input_type": "absolute",
+            "output_max": 0.5,
+            "output_min": -0.5,
+            "kd": 200,
+            "kv": 200,
+            "kp": 1000,
+            "velocity_limits": [-1,1],
+            "kp_limits": [0, 1000],
+            "interpolation": null,
+            "ramp_ratio": 0.2
+        },
+        "head": {
+            "type" : "JOINT_POSITION",
+            "input_max": 1,
+            "input_min": -1,
+            "input_type": "absolute",
+            "output_max": 0.5,
+            "output_min": -0.5,
+            "kd": 200,
+            "kv": 200,
+            "kp": 1000,
+            "velocity_limits": [-1,1],
+            "kp_limits": [0, 1000],
+            "interpolation": null,
+            "ramp_ratio": 0.2
+        },
+        "base": {
+            "type" : "JOINT_VELOCITY",
+            "interpolation": null
+        },
+        "legs": {
+            "type": "JOINT_POSITION",
+            "input_max": 1,
+            "input_min": -1,
+            "output_max": 0.5,
+            "output_min": -0.5,
+            "kd": 200,
+            "kv": 200,
+            "kp": 1000,
+            "velocity_limits": [-1,1],
+            "kp_limits": [0, 1000],
+            "interpolation": null,
+            "ramp_ratio": 0.2
+        }
+    }
+}

--- a/robosuite/scripts/collect_human_demonstrations.py
+++ b/robosuite/scripts/collect_human_demonstrations.py
@@ -20,7 +20,7 @@ from robosuite.controllers.composite.composite_controller import WholeBody
 from robosuite.wrappers import DataCollectionWrapper, VisualizationWrapper
 
 
-def collect_human_trajectory(env, device, arm, max_fr):
+def collect_human_trajectory(env, device, arm, max_fr, goal_update_mode):
     """
     Use the device (keyboard or SpaceNav 3D mouse) to collect a demonstration.
     The rollout trajectory is saved to files in npz format.
@@ -60,7 +60,7 @@ def collect_human_trajectory(env, device, arm, max_fr):
         active_robot = env.robots[device.active_robot]
 
         # Get the newest action
-        input_ac_dict = device.input2action()
+        input_ac_dict = device.input2action(goal_update_mode=goal_update_mode)
 
         # If action is none, then this a reset so we should break
         if input_ac_dict is None:
@@ -279,6 +279,15 @@ if __name__ == "__main__":
         default=False,
         help="(DualSense Only)Reverse the effect of the x and y axes of the joystick.It is used to handle the case that the left/right and front/back sides of the view are opposite to the LX and LY of the joystick(Push LX up but the robot move left in your view)",
     )
+    parser.add_argument(
+        "--goal_update_mode",
+        type=str,
+        default="desired",
+        choices=["desired", "achieved"],
+        help="Used by the device to get the arm's actions. The mode to update the goal in. Can be 'desired' or 'achieved'. If 'desired', the goal is updated based on the current desired goal. "
+            "If 'achieved', the goal is updated based on the current achieved state. "
+            "We recommend using 'achieved' (and input_ref_frame='base') if collecting demonstrations with a mobile base robot."
+    )
     args = parser.parse_args()
 
     # Get controller config
@@ -366,5 +375,5 @@ if __name__ == "__main__":
 
     # collect demonstrations
     while True:
-        collect_human_trajectory(env, device, args.arm, args.max_fr)
+        collect_human_trajectory(env, device, args.arm, args.max_fr, args.goal_update_mode)
         gather_demonstrations_as_hdf5(tmp_directory, new_dir, env_info)


### PR DESCRIPTION
## What this does

This pull request introduces support for specifying the input reference frame (`input_ref_frame`) for whole-body inverse kinematics (IK) controllers, allowing actions and goals to be interpreted in either the world or base frame. It also adds a new `goal_update_mode` parameter to device interfaces, enabling more flexible goal updates based on either desired or achieved states. These changes are reflected in controller configuration, device logic, and demonstration collection scripts.

**Whole-Body IK Reference Frame Support**
* Added `input_ref_frame` as a configurable parameter in `robosuite/controllers/composite/composite_controller.py`, `robosuite/utils/ik_utils.py`, and controller config JSONs, enabling IK actions to be interpreted in either the "world" or "base" frame. [[1]](diffhunk://#diff-3d0e63f5f78027535f15ef8f8bbcb77568e7a33f9ffa93c659a16ee68edc6d49R477) [[2]](diffhunk://#diff-46c93a8bd84222db1640699c10089f3a0d4b8318ee48243156521c10fa2ec0e1R30) [[3]](diffhunk://#diff-46c93a8bd84222db1640699c10089f3a0d4b8318ee48243156521c10fa2ec0e1R68) [[4]](diffhunk://#diff-35404abdf6ea4f425a7c51bc49412bda4ef076e25d5d21376ba448d0bb9059e1R1-R116)
* Modified IK solver logic in `robosuite/utils/ik_utils.py` to transform target poses between frames as needed, ensuring correct pose computation when using the base frame.

**Device and Action Interface Enhancements**
* Updated device interfaces (`robosuite/devices/device.py`, `robosuite/devices/mjgui.py`) to support a new `goal_update_mode` argument, allowing goal updates based on either desired or achieved states, and integrated logic for handling torso actions and reference frames. [[1]](diffhunk://#diff-e75aa032999e4fd6dca1203fa23c6e10f61ae9b5144d2a1f8f7fb637d590be5fL74-R74) [[2]](diffhunk://#diff-e75aa032999e4fd6dca1203fa23c6e10f61ae9b5144d2a1f8f7fb637d590be5fR83-R84) [[3]](diffhunk://#diff-e75aa032999e4fd6dca1203fa23c6e10f61ae9b5144d2a1f8f7fb637d590be5fR139) [[4]](diffhunk://#diff-e75aa032999e4fd6dca1203fa23c6e10f61ae9b5144d2a1f8f7fb637d590be5fR162-R170) [[5]](diffhunk://#diff-233f72b0fdea320642d3002c33ad536670d9ec9b460d6ca33c3af2aa039fa41cL119-R126) [[6]](diffhunk://#diff-233f72b0fdea320642d3002c33ad536670d9ec9b460d6ca33c3af2aa039fa41cL134-L147)
* Improved arm action computation to transform actions to the appropriate reference frame when required, using the new configuration parameter. [[1]](diffhunk://#diff-e75aa032999e4fd6dca1203fa23c6e10f61ae9b5144d2a1f8f7fb637d590be5fR264-R267) [[2]](diffhunk://#diff-e75aa032999e4fd6dca1203fa23c6e10f61ae9b5144d2a1f8f7fb637d590be5fR281-R305)

**Demonstration Collection Improvements**
* Added `goal_update_mode` as a command-line argument in `robosuite/scripts/collect_human_demonstrations.py`, propagating it through the demonstration collection pipeline for more flexible data gathering. [[1]](diffhunk://#diff-774bf2de4129d9bc67911590e0c6b73065a9778687c3e3e859c7cb168be21718L23-R23) [[2]](diffhunk://#diff-774bf2de4129d9bc67911590e0c6b73065a9778687c3e3e859c7cb168be21718L63-R63) [[3]](diffhunk://#diff-774bf2de4129d9bc67911590e0c6b73065a9778687c3e3e859c7cb168be21718R282-R290) [[4]](diffhunk://#diff-774bf2de4129d9bc67911590e0c6b73065a9778687c3e3e859c7cb168be21718L369-R378)

These changes collectively provide more control over how actions and goals are interpreted and updated within the whole-body IK framework and demonstration collection workflows.

## How it was tested

Examples:
```bash
python robosuite/scripts/collect_human_demonstrations.py --controller robosuite/controllers/config/robots/default_pandaomron_whole_body_ik.json --robot PandaOmron --goal_update_mode  achieved
```

Then, press `b` to switch between arm and base modes. Note: the controller can do both base and arm control simultaneously, currently that's not enabled in the teleop script.