### PR TITLE
Fix visibility of parameters in docs for dark mode

### DIFF
--- a/docs/_static/css/theme.css
+++ b/docs/_static/css/theme.css
@@ -135,7 +135,6 @@ h2,
 }
 
 em.sig-param span.n:first-child, em.sig-param span.n:nth-child(2) {
-  color: black;
   font-style: normal;
 }
 


### PR DESCRIPTION
## What this does
Fix visibility of parameters in docs for dark mode, by updating coloring css



## How it was tested
Test by building docs before and after the changes in this PR. Before the changes, the parameters show up as black color on api docs (see image below ). after these changes, they should show up as white.
<img width="719" height="210" alt="image" src="https://github.com/user-attachments/assets/5b7c16fd-56f8-4eca-85cf-9865fe3b36ce" />
