### PR TITLE
Update Python version to 3.11 in workflow

### DIFF
--- a/.github/workflows/update-docs.yaml
+++ b/.github/workflows/update-docs.yaml
@@ -21,7 +21,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.9'
+        python-version: '3.11'
 
     # Install dependencies
     - name: Install Dependencies


### PR DESCRIPTION
## What this does
Update Python version to 3.11 in workflow to fix github deploy docs failing.