### PR TITLE
Add ep_meta parameter to all environment classes

### DIFF
--- a/robosuite/environments/base.py
+++ b/robosuite/environments/base.py
@@ -105,6 +105,7 @@ class MujocoEnv(metaclass=EnvMeta):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # Rendering-specific attributes
         self.has_renderer = has_renderer
@@ -141,7 +142,7 @@ class MujocoEnv(metaclass=EnvMeta):
         self.seed = seed
         self.rng = np.random.default_rng(seed)
 
-        self._ep_meta = {}
+        self._ep_meta = ep_meta
 
         # Load the model
         self._load_model()

--- a/robosuite/environments/manipulation/door.py
+++ b/robosuite/environments/manipulation/door.py
@@ -171,6 +171,7 @@ class Door(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # settings for table top (hardcoded since it's not an essential part of the environment)
         self.table_full_size = (0.8, 0.3, 0.05)
@@ -214,6 +215,7 @@ class Door(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/lift.py
+++ b/robosuite/environments/manipulation/lift.py
@@ -176,6 +176,7 @@ class Lift(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # settings for table top
         self.table_full_size = table_full_size
@@ -219,6 +220,7 @@ class Lift(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/manipulation_env.py
+++ b/robosuite/environments/manipulation/manipulation_env.py
@@ -152,6 +152,7 @@ class ManipulationEnv(RobotEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # Robot info
         robots = list(robots) if type(robots) is list or type(robots) is tuple else [robots]
@@ -196,6 +197,7 @@ class ManipulationEnv(RobotEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     @property

--- a/robosuite/environments/manipulation/nut_assembly.py
+++ b/robosuite/environments/manipulation/nut_assembly.py
@@ -190,6 +190,7 @@ class NutAssembly(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # task settings
         self.single_object_mode = single_object_mode
@@ -244,6 +245,7 @@ class NutAssembly(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/pick_place.py
+++ b/robosuite/environments/manipulation/pick_place.py
@@ -212,6 +212,7 @@ class PickPlace(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # task settings
         self.single_object_mode = single_object_mode
@@ -269,6 +270,7 @@ class PickPlace(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/stack.py
+++ b/robosuite/environments/manipulation/stack.py
@@ -176,6 +176,7 @@ class Stack(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # settings for table top
         self.table_full_size = table_full_size
@@ -219,6 +220,7 @@ class Stack(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action):

--- a/robosuite/environments/manipulation/tool_hang.py
+++ b/robosuite/environments/manipulation/tool_hang.py
@@ -172,6 +172,7 @@ class ToolHang(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # settings for table top
         self.table_full_size = table_full_size
@@ -212,6 +213,7 @@ class ToolHang(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/two_arm_handover.py
+++ b/robosuite/environments/manipulation/two_arm_handover.py
@@ -176,6 +176,7 @@ class TwoArmHandover(TwoArmEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # Task settings
         self.prehensile = prehensile
@@ -225,6 +226,7 @@ class TwoArmHandover(TwoArmEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/two_arm_lift.py
+++ b/robosuite/environments/manipulation/two_arm_lift.py
@@ -173,6 +173,7 @@ class TwoArmLift(TwoArmEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # settings for table top
         self.table_full_size = table_full_size
@@ -216,6 +217,7 @@ class TwoArmLift(TwoArmEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/two_arm_peg_in_hole.py
+++ b/robosuite/environments/manipulation/two_arm_peg_in_hole.py
@@ -193,6 +193,7 @@ class TwoArmPegInHole(TwoArmEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # Assert that the gripper type is None
         assert gripper_types is None, "Tried to specify gripper other than None in TwoArmPegInHole environment!"
@@ -235,6 +236,7 @@ class TwoArmPegInHole(TwoArmEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/two_arm_transport.py
+++ b/robosuite/environments/manipulation/two_arm_transport.py
@@ -174,6 +174,7 @@ class TwoArmTransport(TwoArmEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # settings for table top
         self.tables_boundary = tables_boundary
@@ -221,6 +222,7 @@ class TwoArmTransport(TwoArmEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def reward(self, action=None):

--- a/robosuite/environments/manipulation/wipe.py
+++ b/robosuite/environments/manipulation/wipe.py
@@ -201,6 +201,7 @@ class Wipe(ManipulationEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # Assert that the gripper type is None
         assert (
@@ -299,6 +300,7 @@ class Wipe(ManipulationEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
         # set after init to ensure self.robots is set

--- a/robosuite/environments/robot_env.py
+++ b/robosuite/environments/robot_env.py
@@ -148,6 +148,7 @@ class RobotEnv(MujocoEnv):
         renderer="mjviewer",
         renderer_config=None,
         seed=None,
+        ep_meta={},
     ):
         # First, verify that correct number of robots are being inputted
         self.env_configuration = env_configuration
@@ -233,6 +234,7 @@ class RobotEnv(MujocoEnv):
             renderer=renderer,
             renderer_config=renderer_config,
             seed=seed,
+            ep_meta=ep_meta,
         )
 
     def visualize(self, vis_settings):


### PR DESCRIPTION
## What this does
Sometimes, when there are many possible object options to sample from (e.g., in RoboCasa), environment initialization can take a significant amount of time. This overhead can be reduced by optionally passing episode metadata during initialization, instead of sampling everything at init time.

Examples:
|  Title               | Label           |
|----------------------|-----------------|
| Adds a new feature   | (✨ Feature)     |


## How it was tested

The changes do not break the existing code, as tested using the snippet below
```
import numpy as np
import robosuite as suite

# create environment instance
env = suite.make(
    env_name="Lift", # try with other tasks like "Stack" and "Door"
    robots="Panda",  # try with other robots like "Sawyer" and "Jaco"
    has_renderer=True,
    has_offscreen_renderer=False,
    use_camera_obs=False,
)

# reset the environment
env.reset()

for i in range(1000):
    action = np.random.randn(*env.action_spec[0].shape) * 0.1
    obs, reward, done, info = env.step(action)  # take action in the environment
    env.render()  # render on display
```