### PR TITLE
synchronize rendering context for envs

### DIFF
--- a/robosuite/utils/binding_utils.py
+++ b/robosuite/utils/binding_utils.py
@@ -125,6 +125,8 @@ class MjRenderContext:
             self._set_mujoco_context_and_buffers()
 
     def render(self, width, height, camera_id=None, segmentation=False):
+        self.gl_ctx.make_current()
+
         viewport = mujoco.MjrRect(0, 0, width, height)
 
         # if self.sim.render_callback is not None:


### PR DESCRIPTION
## What this does
Fixes #787. Essentially fixes bug with rendering by synchronizing rendering context before calling render

## How it was tested

1) Made sure  demo playback still works
2) tested @ShahRutav's script with SyncVectorEnvs from #787 
3) Made sure fps doesnt take a hit

@kevin-thankyou-lin can you try the above as well?