### PR TITLE
fix an bug where the naming of the kwarg collides with the property torque_compensation

### DIFF
--- a/robosuite/controllers/parts/generic/joint_vel.py
+++ b/robosuite/controllers/parts/generic/joint_vel.py
@@ -124,7 +124,7 @@ class JointVelocityController(Controller):
         self.current_vel = np.zeros(self.joint_dim)  # Current velocity setpoint, pre-compensation
         self.torques = None  # Torques returned every time run_controller is called
 
-        self.torque_compensation = kwargs.get("use_torque_compensation", True)
+        self.use_torque_compensation = kwargs.get("use_torque_compensation", True)
 
     def set_goal(self, velocities):
         """
@@ -189,7 +189,7 @@ class JointVelocityController(Controller):
             self.summed_err += err
 
         # Compute command torques via PID velocity controller plus gravity compensation torques
-        if self.torque_compensation:
+        if self.use_torque_compensation:
             torques = (
                 self.kp * err + self.ki * self.summed_err + self.kd * self.derr_buf.average + self.torque_compensation
             )


### PR DESCRIPTION
When running the control demo (demo_control.py) with the JOINT_VELOCITY controller, the code crashes.
For example use the options: Lift, Panda, JOINT_VELOCITY.
After this fix, the demo runs as expected.

- the fix is renaming the class attribute `torque_compensation` to `use_torque_compensation` so that it doesn't collide with the class property `torque_compensation`