### PR TITLE
Fix fatal typo in joint velocity controller torque compensation

### DIFF
--- a/robosuite/controllers/parts/generic/joint_vel.py
+++ b/robosuite/controllers/parts/generic/joint_vel.py
@@ -124,7 +124,7 @@ class JointVelocityController(Controller):
         self.current_vel = np.zeros(self.joint_dim)  # Current velocity setpoint, pre-compensation
         self.torques = None  # Torques returned every time run_controller is called
 
-        self.torque_compensation = kwargs.get("use_torque_compensation", True)
+        self.use_torque_compensation = kwargs.get("use_torque_compensation", True)
 
     def set_goal(self, velocities):
         """
@@ -189,7 +189,7 @@ class JointVelocityController(Controller):
             self.summed_err += err
 
         # Compute command torques via PID velocity controller plus gravity compensation torques
-        if self.torque_compensation:
+        if self.use_torque_compensation:
             torques = (
                 self.kp * err + self.ki * self.summed_err + self.kd * self.derr_buf.average + self.torque_compensation
             )


### PR DESCRIPTION
## What this does
Fix a fatal typo in joint velocity controller (name conflict with flag for using torque compensation)

## How it was tested
Tested using the following configuration file:
```json
{
    "type": "BASIC",
    "body_parts": {
        "arms": {
            "right": {
                "type": "JOINT_VELOCITY",
                "input_max": 1,
                "input_min": -1,
                "output_max": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
                "output_min": [-1.0, -1.0, -1.0, -1.0, -1.0, -1.0, -1.0],
                "kp": 150,
                "damping_ratio": 1,
                "input_type": "delta",
                "interpolation": null,
                "ramp_ratio": 0.2,
                "gripper": {
                    "type": "GRIP"
                }
            }
        }
    }
}
```

Test script:
```python
import os

import numpy as np

import robosuite
from robosuite.controllers import load_composite_controller_config

# Point this to the above file
controller_file = os.path.join(os.path.dirname(__file__), "panda_joint_controller.json")
controller_config = load_composite_controller_config(controller=controller_file)

freq = 20
episode_length=800
env = robosuite.make(
    "Stack",
    robots=["Panda"],
    gripper_types="default",
    controller_configs=controller_config,
    env_configuration="opposed",    # What are the options?
    has_renderer=False,
    #render_camera="frontview",
    has_offscreen_renderer=True,
    control_freq=freq,
    horizon=episode_length,
    use_object_obs=False,
    use_camera_obs=True,
    camera_names="agentview",
    camera_heights=80,
    camera_widths=80,
)

print(env.action_spec)  # Should be 8 dimensional due to 7 joint + gripper
```

Crashes with old, works with new.

## How to checkout & try? (for the reviewer)
Run the provided test script using the provided json file.