### PR TITLE
make mink optional

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -36,7 +36,7 @@ jobs:
         pip install -e .
         if [ -f requirements.txt ]; then 
           pip install -r requirements.txt
-          pip install mink
+          pip install mink==0.0.5
         fi
         if [ -f requirements-extra.txt ]; then 
           pip install -r requirements-extra.txt

--- a/robosuite/__init__.py
+++ b/robosuite/__init__.py
@@ -38,7 +38,7 @@ try:
 
 except:
     ROBOSUITE_DEFAULT_LOGGER.warning(
-        "Could not load the mink-based whole-body IK. Make sure you install related import properly, otherwise you will not be able to use the default IK controller setting for GR1 robot."
+        "Could not load the mink-based whole-body IK. Make sure you install related import properly (e.g. pip install mink==0.0.5), otherwise you will not be able to use the default IK controller setting for GR1 robot."
     )
 
 __version__ = "1.5.2"

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ setup(
         "numba>=0.49.1",
         "scipy>=1.2.3",
         "mujoco>=3.3.0",
-        "mink==0.0.5",
         "qpsolvers[quadprog]>=4.3.1",
         "Pillow",
         "opencv-python",
@@ -28,6 +27,11 @@ setup(
         "pytest",
         "tqdm",
     ],
+    extras_require={
+        "mink": [
+            "mink==0.0.5",
+        ],
+    },
     eager_resources=["*"],
     include_package_data=True,
     python_requires=">=3",


### PR DESCRIPTION
## What this does
Remove the mink dependency as a required package to install, because it interferes with other installations too much. Also updated workflow file to install mink==0.0.5 explicitly

## How it was tested
Tried uninstalling mink (pip uninstall mink) and robosuite still works.

## SECTION TO REMOVE BEFORE SUBMITTING YOUR PR
**Note**: Anyone in the community is free to review the PR once the tests have passed. Feel free to tag
members/contributors who may be interested in your PR. Try to avoid tagging more than 3 people.

**Note**: Before submitting this PR, please read the [contributor guideline](https://github.com/ARISE-Initiative/robosuite/blob/master/CONTRIBUTING.md).