### PR TITLE
fix: close file handle in MjSim.get_xml() to fix ResourceWarning (#801)

### DIFF
--- a/robosuite/utils/binding_utils.py
+++ b/robosuite/utils/binding_utils.py
@@ -503,7 +503,8 @@ class MjModel(metaclass=_MjModelMeta):
         with TemporaryDirectory() as td:
             filename = os.path.join(td, "model.xml")
             ret = mujoco.mj_saveLastXML(filename.encode(), self._model)
-            return open(filename).read()
+            with open(filename) as f:
+                return f.read()
 
     def get_joint_qpos_addr(self, name):
         """


### PR DESCRIPTION
## Description

Fixes #801

The `get_xml()` method in `MjSim` (in `robosuite/utils/binding_utils.py`) uses `open(filename).read()` without properly closing the file handle. This causes a `ResourceWarning: unclosed file` whenever `get_xml()` or `get_state()` is called.

## Fix

Changed the bare `open(filename).read()` call to use a context manager (`with` statement) so the file is properly closed after reading:

```python
# Before
return open(filename).read()

# After
with open(filename) as f:
    return f.read()
```

This is a minimal, safe change that ensures proper resource cleanup without altering any functionality.

## Testing

The fix is straightforward and follows standard Python best practices for file I/O. The `with` statement ensures the file handle is closed when the block exits, eliminating the `ResourceWarning`.