### PR TITLE
fix unclosed file handle in get_xml

### DIFF
--- a/robosuite/utils/binding_utils.py
+++ b/robosuite/utils/binding_utils.py
@@ -505,7 +505,8 @@ class MjModel(metaclass=_MjModelMeta):
         with TemporaryDirectory() as td:
             filename = os.path.join(td, "model.xml")
             ret = mujoco.mj_saveLastXML(filename.encode(), self._model)
-            return open(filename).read()
+            with open(filename) as f:
+                return f.read()
 
     def get_joint_qpos_addr(self, name):
         """


### PR DESCRIPTION
Fixes #801

`get_xml()` in `binding_utils.py` called `open(filename).read()` without a context manager, leaving the file handle open and causing `ResourceWarning: unclosed file` every time `get_state()` is called.

Fixed by wrapping in a `with` block so the file is properly closed after reading.