### PR TITLE
fix(deps): pin mujoco>=3.3.0,<3.10 (avoid mj_fullM API break)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         "numpy>=1.13.3",
         "numba>=0.49.1",
         "scipy>=1.2.3",
-        "mujoco>=3.3.0",
+        "mujoco>=3.3.0,<3.10",  # 3.10 changed mj_fullM signature; breaks controllers/parts/controller.py
         "qpsolvers[quadprog]>=4.3.1",
         "Pillow",
         "opencv-python",


### PR DESCRIPTION
Pin `mujoco>=3.3.0,<3.10` to avoid `mj_fullM` API break.

## What this does
With the current uncapped mujoco dependency, the latest version (3.10 as of now) of mujoco is installed. 
This PR avoids the [breaking API changes of mujoco 3.10](https://mujoco.readthedocs.io/en/3.10.0/changelog.html).

## How it was tested
- Ran pytest with mujoco==3.3, 3.4, ..., 3.10. Failed only with 3.10 due to the API change.

## How to checkout & try? (for the reviewer)
- Run pytest with different versions of mujoco.
