### PR TITLE
fix: rebind domain randomization modders after a hard reset

### DIFF
--- a/robosuite/wrappers/domain_randomization_wrapper.py
+++ b/robosuite/wrappers/domain_randomization_wrapper.py
@@ -207,15 +207,16 @@ class DomainRandomizationWrapper(Wrapper):
         # normal env reset
         ret = super().reset()
 
+        # a hard reset frees the old sim and builds a new one, so point the
+        # modders at it before reading any model parameters from them
+        for modder in self.modders:
+            modder.update_sim(self.env.sim)
+
         # save the original env parameters
         self.save_default_domain()
 
         # reset counter for doing domain randomization at a particular frequency
         self.step_counter = 0
-
-        # update sims
-        for modder in self.modders:
-            modder.update_sim(self.env.sim)
 
         if self.randomize_on_reset:
             # domain randomize + regenerate observation

--- a/tests/test_environments/test_domain_randomization.py
+++ b/tests/test_environments/test_domain_randomization.py
@@ -1,0 +1,41 @@
+"""
+Test that DomainRandomizationWrapper survives a hard reset.
+
+When an environment uses the "mujoco" renderer, a hard reset frees the old MjSim
+and builds a new one. The wrapper's modders keep a reference to the freed sim, so
+saving the default domain must rebind them to the new sim first. Otherwise the
+second reset raises `AttributeError: 'MjSim' object has no attribute 'model'`.
+
+See https://github.com/ARISE-Initiative/robosuite/issues/426.
+"""
+import numpy as np
+
+import robosuite as suite
+from robosuite.wrappers import DomainRandomizationWrapper
+
+
+def test_domain_randomization_hard_reset():
+
+    env = suite.make(
+        env_name="Lift",
+        robots="Panda",
+        has_renderer=False,
+        has_offscreen_renderer=False,
+        use_camera_obs=False,
+        renderer="mujoco",
+    )
+    # randomize_color needs mujoco==3.1.1, so leave it off here
+    env = DomainRandomizationWrapper(env, randomize_color=False)
+
+    # the first reset builds the initial sim; each later hard reset frees it and
+    # builds a new one, which is what used to break the modders
+    for _ in range(3):
+        env.reset()
+        env.step(np.zeros(env.action_dim))
+
+    env.close()
+
+
+if __name__ == "__main__":
+
+    test_domain_randomization_hard_reset()


### PR DESCRIPTION
## What this does

Fixes #426 (🐛 Bug)

When an environment uses the `mujoco` renderer, a hard reset frees the old `MjSim` and builds a new one (`_destroy_sim` then `_initialize_sim` in `MujocoEnv.reset`). `DomainRandomizationWrapper.reset` called `save_default_domain()` before rebinding its modders to the new sim, so the modders still pointed at the freed sim. Reading a model parameter from it then raised:

```
AttributeError: 'MjSim' object has no attribute 'model'
```

Reproducer from the issue:

```python
import robosuite as suite
from robosuite.wrappers import DomainRandomizationWrapper

env = suite.make("Door", robots="Panda", has_renderer=True, has_offscreen_renderer=False, use_camera_obs=False)
env = DomainRandomizationWrapper(env)
env.reset()
```

The `update_sim` loop that rebinds the modders already existed, it just ran after `save_default_domain()`. Moving it ahead of the save so the modders read from the live sim is enough to fix it. This is also what was suggested in the issue thread.

## How it was tested

Added `test_domain_randomization_hard_reset` in `tests/test_environments/test_domain_randomization.py`. It wraps a `Lift` env with the `mujoco` renderer and resets it across several hard resets. The test fails on `master` with the `AttributeError` above and passes with this change. `randomize_color` is left off in the test because `TextureModder` requires `mujoco==3.1.1`.

`black`, `isort` and `flake8` are clean on the changed files.

## How to checkout & try? (for the reviewer)

```bash
python -m pytest tests/test_environments/test_domain_randomization.py
```